### PR TITLE
Decode Database After Calling Save

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -59,6 +59,12 @@ class PyKeePass(object):
                 )
             )
 
+        self.kdbx = KDBX.parse_file(
+            self.filename,
+            password=self.password,
+            keyfile=self.keyfile
+        )
+
     @property
     def version(self):
         return (


### PR DESCRIPTION
When calling the save function the protected elements of the database tree become encoded again. That means that all passwords are encrypted and not user-readable. This is bad if we want to continue to work on the database after saving instead of instantly closing it. That means all passwords are gibberish after the save. In order to prevent this we reparse the database to decode the protected elements again.