### PR TITLE
Make 'path' ignore other arguments.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,12 +275,12 @@ the data that this attachment points to.  Raises ``AttachmentError`` if data doe
    >>> e = kp.add_entry(kp.root_group, title='foo', username='', password='')
 
    # add attachment data to the db
-   >>> attachment_id = kp.add_binary(b'Hello world')
-   >>> kp.attachments
+   >>> binary_id = kp.add_binary(b'Hello world')
+   >>> kp.binaries
    [b'Hello world']
 
    # add attachment reference to entry
-   >>> a = e.add_attachment(attachment_id, 'hello.txt')
+   >>> a = e.add_attachment(binary_id, 'hello.txt')
    >>> a
    Attachment: 'hello.txt' -> 0
      
@@ -294,14 +294,18 @@ the data that this attachment points to.  Raises ``AttachmentError`` if data doe
    >>> e.attachments
    [Attachment: 'hello.txt' -> 0]
 
+   # list all attachments in the database
+   >>> kp.attachments
+   [Attachment: 'hello.txt' -> 0]
+
    # search attachments
-   >>> kp.find_attachments(filename='he.*', regex=True)
+   >>> kp.find_attachments(filename='hello.txt')
    [Attachment: 'hello.txt' -> 0]
 
    # delete attachment reference
    >>> e.delete_attachment(a)
 
-   # or, delete both attachment reference and binary
+   # or, delete binary and all associated references
    >>> kp.delete_binary(attachment_id)
 
 Miscellaneous

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Returns entries which match all provided parameters, where ``title``, ``username
 .. _XSLT style: https://www.xml.com/pub/a/2003/06/04/tr.html
 .. _flags: https://www.w3.org/TR/xpath-functions/#flags 
 
-The ``path`` string can be a direct path to an entry, or (when ending in ``/``) the path to the group to recursively search under.
+The ``path`` string is a full path to an entry (ex. ``'foobar_group/foobar_entry'``).  This implies ``first=True``.  All other arguments are ignored when this is given.  This is useful for handling user input.
 
 The ``string`` dict allows for searching custom string fields.  ex. ``{'custom_field1': 'custom value', 'custom_field2': 'custom value'}``
 
@@ -117,7 +117,7 @@ where ``name``, ``path``, ``uuid`` and ``notes`` are strings.  This function has
 .. _XSLT style: https://www.xml.com/pub/a/2003/06/04/tr.html
 .. _flags: https://www.w3.org/TR/xpath-functions/#flags 
 
-The ``path`` string must end in ``/``.
+The ``path`` string is a full path to a group (ex. ``'foobar_group/sub_group'``).  This implies ``first=True``.  All other arguments are ignored when this is given.  This is useful for handling user input.
 
 The ``group`` argument determines what ``Group`` to search under, and the ``recursive`` boolean controls whether to search recursively.
 

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -457,7 +457,7 @@ class PyKeePass(object):
 
     @property
     def attachments(self):
-        self.find_attachments(filename='.*', regex=True)
+        return self.find_attachments(filename='.*', regex=True)
 
     @property
     def binaries(self):

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -184,7 +184,7 @@ class PyKeePass(object):
             if group_path:
                 for group in group_path.split('/'):
                     xp += path_xp[regex]['group'].format(group, flags=flags)
-            if element and 'Entry' in prefix:
+            if 'Entry' in prefix:
                 xp += path_xp[regex]['entry'].format(element, flags=flags)
             elif element and 'Group' in prefix:
                 xp += path_xp[regex]['group'].format(element, flags=flags)

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -171,41 +171,44 @@ class PyKeePass(object):
 
         xp = ''
 
-        # resolve path before handling any keys
         if path is not None:
 
+            first = True
+
             xp += '/KeePassFile/Root/Group'
-            # split provided path into group and entry
-            group_path = os.path.dirname(path).lstrip('/')
-            entry = os.path.basename(path)
-            # build xpath from group_path and entry
+            path = path.strip('/')
+            # split provided path into group and element
+            group_path = os.path.dirname(path)
+            element = os.path.basename(path)
+            # build xpath from group_path and element
             if group_path:
                 for group in group_path.split('/'):
                     xp += path_xp[regex]['group'].format(group, flags=flags)
-            if entry:
-                xp += path_xp[regex]['entry'].format(entry, flags=flags)
+            if element and 'Entry' in prefix:
+                xp += path_xp[regex]['entry'].format(element, flags=flags)
+            elif element and 'Group' in prefix:
+                xp += path_xp[regex]['group'].format(element, flags=flags)
 
-        elif tree is not None:
-            xp += '.'
-            
-        # FIXME: ideally, this should be 'if kwargs.keys() or path is not None'
-        #        but this is a breaking change. Pending issue 127
-        if kwargs.keys():
-            xp += prefix
+        else:
+            if tree is not None:
+                xp += '.'
 
-        # handle searching custom string fields
-        if 'string' in kwargs.keys():
-            for key, value in kwargs['string'].items():
-                xp += keys_xp[regex]['string'].format(key, value, flags=flags)
+            if kwargs.keys():
+                xp += prefix
 
-            kwargs.pop('string')
+            # handle searching custom string fields
+            if 'string' in kwargs.keys():
+                for key, value in kwargs['string'].items():
+                    xp += keys_xp[regex]['string'].format(key, value, flags=flags)
 
-        # build xpath to filter results with specified attributes
-        for key, value in kwargs.items():
-            if key not in keys_xp[regex].keys():
-                raise TypeError('Invalid keyword argument "{}"'.format(key))
+                kwargs.pop('string')
 
-            xp += keys_xp[regex][key].format(value, flags=flags)
+            # build xpath to filter results with specified attributes
+            for key, value in kwargs.items():
+                if key not in keys_xp[regex].keys():
+                    raise TypeError('Invalid keyword argument "{}"'.format(key))
+
+                xp += keys_xp[regex][key].format(value, flags=flags)
 
         res = self._xpath(
             xp,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -87,11 +87,11 @@ class EntryFindTests3(KDBX3Tests):
         self.assertEqual('root entry notes', results.notes)
 
     def test_find_entries_by_path(self):
-        results = self.kp.find_entries(path='foobar_group/', title='group_entry')
-        self.assertEqual(len(results), 1)
         results = self.kp.find_entries(path='foobar_group/group_entry')
-        self.assertEqual(len(results), 1)
-        results = self.kp.find_entries(path='foobar_group/', title='Group_entry', regex=True, flags='i', first=True)
+        self.assertIsInstance(results, Entry)
+        results = self.kp.find_entries(path='foobar_group/')
+        self.assertEqual(results, None)
+        results = self.kp.find_entries(path='foobar_group/Group_entry', regex=True, flags='i', first=True)
         self.assertIsInstance(results, Entry)
         self.assertEqual('group_entry', results.title)
 
@@ -164,7 +164,7 @@ class EntryFindTests3(KDBX3Tests):
 
         sub_group = self.kp.add_group(self.kp.root_group, 'sub_group')
         self.kp.move_entry(entry, sub_group)
-        results = self.kp.find_entries(path='sub_group/', title='test_add_entry_title', first=True)
+        results = self.kp.find_entries(path='sub_group/test_add_entry_title', first=True)
         self.assertEqual(results.title, entry.title)
 
         self.kp.delete_entry(entry)
@@ -220,9 +220,11 @@ class GroupFindTests3(KDBX3Tests):
 
     def test_find_groups_by_path(self):
         results = self.kp.find_groups_by_path('/foobar_group/subgroup/')
-        self.assertIsInstance(results[0], Group)
-        results = self.kp.find_groups(path='/foobar_group/', name='subgroup', first=True)
+        self.assertIsInstance(results, Group)
+        results = self.kp.find_groups(path='/foobar_group/subgroup/', first=True)
         self.assertEqual(results.name, 'subgroup')
+        results = self.kp.find_groups(path='foobar_group/group_entry')
+        self.assertEqual(results, None)
 
     def test_find_groups_by_uuid(self):
         results = self.kp.find_groups_by_uuid('lRVaMlMXoQ/U5NDCAwJktg==', first=True)
@@ -234,12 +236,6 @@ class GroupFindTests3(KDBX3Tests):
         results = self.kp.find_groups(notes='group notes')
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].uuid, 'lRVaMlMXoQ/U5NDCAwJktg==')
-
-    def test_find_groups(self):
-        results = self.kp.find_groups(path='/foobar_group/')
-        self.assertIsInstance(results[0], Group)
-        results = self.kp.find_groups(path='/foobar_group/', name='subgroup', first=True)
-        self.assertEqual(results.name, 'subgroup')
 
     def test_groups(self):
         results = self.kp.groups
@@ -258,17 +254,17 @@ class GroupFindTests3(KDBX3Tests):
         base_group.notes = ''
         self.assertEqual(base_group.notes, '')
 
-        results = self.kp.find_groups(path='base_group/', name='sub_group', first=True)
+        results = self.kp.find_groups(path='base_group/sub_group/', first=True)
         self.assertIsInstance(results, Group)
         self.assertEqual(results.name, sub_group.name)
         self.assertTrue(results.uuid != None)
 
         self.kp.move_group(sub_group2, sub_group)
-        results = self.kp.find_groups(path='base_group/sub_group/', name='sub_group2', first=True)
+        results = self.kp.find_groups(path='base_group/sub_group/sub_group2/', first=True)
         self.assertEqual(results.name, sub_group2.name)
 
         self.kp.delete_group(sub_group)
-        results = self.kp.find_groups(path='base_group/', name='sub_group', first=True)
+        results = self.kp.find_groups(path='base_group/sub_group/', first=True)
         self.assertIsNone(results)
 
         # ---------- Groups representation -----------

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,6 +8,7 @@ from dateutil import tz
 from pykeepass import icons, PyKeePass
 from pykeepass.entry import Entry
 from pykeepass.group import Group
+from pykeepass.attachment import Attachment
 from pykeepass.kdbx_parsing import KDBX
 from lxml.etree import Element
 import os
@@ -426,8 +427,15 @@ class AttachmentTests3(KDBX3Tests):
             keyfile=os.path.join(base_dir, self.keyfile)
         )
 
+    def test_attachments(self):
+        binary_id = self.kp.add_binary(b'foo')
+        e = self.kp.entries[0]
+        e.add_attachment(binary_id, 'foobar.txt')
+        self.assertEqual(len(self.kp.attachments), 1)
+        self.assertEqual(type(self.kp.attachments[0]), Attachment)
+
     def test_create_delete_attachment(self):
-        attachment_id = self.kp.add_binary(b'Ronald McDonald Trump')
+        binary_id = self.kp.add_binary(b'Ronald McDonald Trump')
         self.kp.save()
         self.open()
         self.assertEqual(self.kp.binaries[-1], b'Ronald McDonald Trump')
@@ -441,15 +449,15 @@ class AttachmentTests3(KDBX3Tests):
     def test_attachment_reference_decrement(self):
         e = self.kp.entries[0]
 
-        attachment_id1 = self.kp.add_binary(b'foobar')
-        attachment_id2 = self.kp.add_binary(b'foobar2')
+        binary_id1 = self.kp.add_binary(b'foobar')
+        binary_id2 = self.kp.add_binary(b'foobar2')
 
-        attachment1 = e.add_attachment(attachment_id1, 'foo.txt')
-        attachment2 = e.add_attachment(attachment_id2, 'foo.txt')
+        attachment1 = e.add_attachment(binary_id1, 'foo.txt')
+        attachment2 = e.add_attachment(binary_id2, 'foo.txt')
 
-        self.kp.delete_binary(attachment_id1)
+        self.kp.delete_binary(binary_id1)
 
-        self.assertEqual(attachment2.id, attachment_id2 - 1)
+        self.assertEqual(attachment2.id, binary_id2 - 1)
 
     def tearDown(self):
         os.remove(os.path.join(base_dir, 'test_attachment.kdbx'))


### PR DESCRIPTION
This is what I proposed in #127.  It also fixes a bug where `find_entries('foobar_group/sub_group/', first=True)` could return a `Group` instead of an `Entry`.