### PR TITLE
Fix <= version (4,0) ~version 3 add_binary ID referencing

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -26,7 +26,8 @@ reserved_keys = [
     'Tags',
     'IconID',
     'Times',
-    'History'
+    'History',
+    'Notes'
 ]
 
 # FIXME python2

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -195,14 +195,14 @@ class Entry(BaseElement):
     def autotype_enabled(self, value):
         enabled = self._element.find('AutoType/Enabled')
         if value is not None:
-            enabled.text= str(value)
+            enabled.text = str(value)
         else:
             enabled.text = None
 
     @property
     def autotype_sequence(self):
         sequence = self._element.find('AutoType/DefaultSequence')
-        return sequence.text if sequence else None
+        return sequence.text if sequence is not None else None
 
     @autotype_sequence.setter
     def autotype_sequence(self, value):

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -494,14 +494,14 @@ class PyKeePass(object):
                 # gzip compression
                 data = zlib.compress(data)
             data = base64.b64encode(data).decode()
+
             # set ID for Binary Element
             ID = str(len(self.binaries) + 1)
-            
+
             # add binary element to XML
             binaries.append(
                 E.Binary(data, ID=ID, Compressed=str(compressed))
             )
-            #print(len(self.binaries), self._xpath('/KeePassFile/Meta/Binaries'), len(binaries))
 
         # return attachment id
         return len(self.binaries)

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -470,7 +470,7 @@ class PyKeePass(object):
                         zlib.MAX_WBITS | 32
                     )
                 else:
-                    data = base64.b64decode(elem.text)
+                    data = base64.b64decode(elem.text).decode()
                 attachments.append(data)
 
         return attachments
@@ -493,12 +493,15 @@ class PyKeePass(object):
             if compressed:
                 # gzip compression
                 data = zlib.compress(data)
-            data = base64.b64encode(data).decode
-
+            data = base64.b64encode(data).decode()
+            # set ID for Binary Element
+            ID = str(len(self.binaries) + 1)
+            
             # add binary element to XML
             binaries.append(
-                E.Binary(data, Compressed=str(compressed))
+                E.Binary(data, ID=ID, Compressed=str(compressed))
             )
+            #print(len(self.binaries), self._xpath('/KeePassFile/Meta/Binaries'), len(binaries))
 
         # return attachment id
         return len(self.binaries)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lxml==4.3.0
+lxml==4.3.1
 pycryptodome==3.7.3
 construct==2.9.45
 argon2-cffi==19.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ lxml==4.3.0
 pycryptodome==3.7.3
 construct==2.9.45
 argon2-cffi==19.1.0
-python-dateutil==2.7.5
+python-dateutil==2.8.0
 future==0.17.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pykeepass",
-    version="3.0.2",
+    version="3.0.3",
     license="GPL3",
     description="Python library to interact with keepass databases "
                 "(supports KDBX3 and KDBX4)",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -110,6 +110,7 @@ class EntryFindTests3(KDBX3Tests):
     def test_find_entries_by_autotype_sequence(self):
         results = self.kp.find_entries(autotype_sequence='{TAB}', regex=True)
         self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].autotype_sequence, '{USERNAME}{TAB}{PASSWORD}{ENTER}')
 
     def test_find_entries_by_autotype_enabled(self):
         results = self.kp.find_entries(autotype_enabled=True)


### PR DESCRIPTION
I inspected a kdbx created by KeePass, and found that /KeePassFile/Meta/Binaries/Binary requires an ID key to reference the proper data, and fixed a `data = base64.b64encode(data).decode` typo which was not decoding the data.

See https://github.com/pschmitt/pykeepass/issues/146#issue-421943414 for debug details