### PR TITLE
changed entry.touch() to use member functions to change atime/mtime

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -264,9 +264,10 @@ class Entry(BaseElement):
         '''
         Update last access time of an entry
         '''
-        self._element.Times.LastAccessTime = datetime.utcnow()
+        now = datetime.now()
+        self.atime = now
         if modify:
-            self._element.Times.LastModificationTime = datetime.utcnow()
+            self.mtime = now
 
     def save_history(self):
         '''

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,7 +16,6 @@ import os
 import shutil
 import unittest
 import logging
-import time
 
 """
 Missing Tests:
@@ -378,30 +377,23 @@ class EntryTests3(KDBX3Tests):
 
     def test_touch(self):
         """Test for https://github.com/pschmitt/pykeepass/issues/120"""
-        entry = Entry(
-            'title',
-            'username',
-            'password',
-            kp=self.kp
-        )
+        entry = self.kp.find_entries_by_title('root_entry', first=True)
         atime = entry.atime
         mtime = entry.mtime
         ctime = entry.ctime
-        time.sleep(1)
         entry.touch()
         self.assertTrue(atime < entry.atime)
         self.assertEqual(mtime, entry.mtime)
         self.assertEqual(ctime, entry.ctime)
+
+        entry = self.kp.find_entries_by_title('foobar_entry', first=True)
         atime = entry.atime
-        time.sleep(1)
+        mtime = entry.mtime
+        ctime = entry.ctime
         entry.touch(modify=True)
         self.assertTrue(atime < entry.atime)
         self.assertTrue(mtime < entry.mtime)
         self.assertEqual(ctime, entry.ctime)
-
-
-
-
 
     def test_autotype_no_default_sequence(self):
         entry = Entry(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,6 +16,7 @@ import os
 import shutil
 import unittest
 import logging
+import time
 
 """
 Missing Tests:
@@ -374,6 +375,33 @@ class EntryTests3(KDBX3Tests):
 
         entry.expiry_time = past_time
         self.assertTrue(entry.expired)
+
+    def test_touch(self):
+        """Test for https://github.com/pschmitt/pykeepass/issues/120"""
+        entry = Entry(
+            'title',
+            'username',
+            'password',
+            kp=self.kp
+        )
+        atime = entry.atime
+        mtime = entry.mtime
+        ctime = entry.ctime
+        time.sleep(1)
+        entry.touch()
+        self.assertTrue(atime < entry.atime)
+        self.assertEqual(mtime, entry.mtime)
+        self.assertEqual(ctime, entry.ctime)
+        atime = entry.atime
+        time.sleep(1)
+        entry.touch(modify=True)
+        self.assertTrue(atime < entry.atime)
+        self.assertTrue(mtime < entry.mtime)
+        self.assertEqual(ctime, entry.ctime)
+
+
+
+
 
     def test_autotype_no_default_sequence(self):
         entry = Entry(


### PR DESCRIPTION
https://github.com/libkeepass/pykeepass/issues/120 is open for some time and I almost forgot about it
here's another try to get this fixed

I made 2 changes:
- I changed the code for the touch function to use the atime.setter/mtime.setter from the BaseElement class
- I added a test in the EntryTests class to test the touch function. Sorry for the sleep statement but I had no better idea

Hope this helps
BoomerB