### PR TITLE
deleted wrong definition of find_groups_by_path

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -233,17 +233,6 @@ class PyKeePass(object):
         return res
 
 
-    def find_groups_by_path(self, group_path_str=None, regex=False, flags=None,
-                            group=None, first=False):
-
-        return self.find_groups(name=group_name,
-                                regex=regex,
-                                flags=flags,
-                                group=group,
-                                first=first
-        )
-
-
     def find_groups_by_name(self, group_name, regex=False, flags=None,
                             group=None, first=False):
 


### PR DESCRIPTION
as described in https://github.com/libkeepass/pykeepass/issues/171
the function find_groups_by_path was defined twice. the first was wrong and that's what VS Code marked as a problem. the second definition was correct and that's why the tests ran through without problems.
So, I deleted the first definition to keep the code nice and clean