### PR TITLE
make sure timestamps are not converted twice to UTC

### DIFF
--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -22,13 +22,11 @@ class BaseElement(object):
         )
         if icon:
             self._element.append(E.IconID(icon))
-        current_time_str = self._encode_time(datetime.utcnow())
+        current_time_str = self._encode_time(datetime.now())
         if expiry_time:
-            expiry_time_str = self._encode_time(
-                self._datetime_to_utc(expiry_time)
-            )
+            expiry_time_str = self._encode_time(expiry_time)
         else:
-            expiry_time_str = self._encode_time(datetime.utcnow())
+            expiry_time_str = current_time_str
 
         self._element.append(
             E.Times(


### PR DESCRIPTION
I noticed the following

KDBX V3
```
>>> from pykeepass import PyKeePass
>>> database = 'test3.kdbx'
>>> password = 'password'
>>> keyfile = 'test3.key'
>>> kp = PyKeePass(database, password=password, keyfile=keyfile)
>>> 
>>> from datetime import datetime, timedelta
>>> from dateutil import tz
>>> from pykeepass.entry import Entry
>>> now = datetime.now(tz.gettz())
>>> utc = datetime.now(tz.gettz('UTC'))
>>> entry = Entry(
...     'title',
...     'username',
...     'password',
...     kp=kp
... )
>>> 
>>> now
datetime.datetime(2019, 9, 20, 9, 23, 40, 885385, tzinfo=tzfile('/etc/localtime'))
>>> utc
datetime.datetime(2019, 9, 20, 7, 23, 40, 885720, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.atime
datetime.datetime(2019, 9, 20, 5, 23, 40, 886515, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.expiry_time
datetime.datetime(2019, 9, 20, 5, 23, 40, 886800, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
```

KDBX V4
```
>>> from pykeepass import PyKeePass
>>> database = 'test4.kdbx'
>>> password = 'password'
>>> keyfile = 'test4.key'
>>> kp = PyKeePass(database, password=password, keyfile=keyfile)
>>> 
>>> from datetime import datetime, timedelta
>>> from dateutil import tz
>>> from pykeepass.entry import Entry
>>> now = datetime.now(tz.gettz())
>>> utc = datetime.now(tz.gettz('UTC'))
>>> entry = Entry(
...     'title',
...     'username',
...     'password',
...     kp=kp
... )
>>> 
>>> now
datetime.datetime(2019, 9, 20, 9, 24, 46, 473847, tzinfo=tzfile('/etc/localtime'))
>>> utc
datetime.datetime(2019, 9, 20, 7, 24, 46, 474475, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.atime
datetime.datetime(2019, 9, 20, 5, 24, 46, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.expiry_time
datetime.datetime(2019, 9, 20, 5, 24, 46, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
```

as you can see, there are 2 hours between localtime and UTC and there are another 2 hours between utc and entry.atime. so, it looks like the timestamp is converted twice

analysis:
```
current_time_str = self._encode_time(datetime.utcnow())
```
datetime.utcnow() returns a timestamp without tzinfo. _encode_time then calls _datetime_to_utc which notices the lack of tzinfo and assumes it's localtime.

with the patch applied, you can see that entry.atime matches utc

KDBX V3
```
>>> from pykeepass import PyKeePass
>>> database = 'test3.kdbx'
>>> password = 'password'
>>> keyfile = 'test3.key'
>>> kp = PyKeePass(database, password=password, keyfile=keyfile)
>>> 
>>> from datetime import datetime, timedelta
>>> from dateutil import tz
>>> from pykeepass.entry import Entry
>>> now = datetime.now(tz.gettz())
>>> utc = datetime.now(tz.gettz('UTC'))
>>> entry = Entry(
...     'title',
...     'username',
...     'password',
...     kp=kp
... )
>>> 
>>> now
datetime.datetime(2019, 9, 20, 9, 18, 39, 262217, tzinfo=tzfile('/etc/localtime'))
>>> utc
datetime.datetime(2019, 9, 20, 7, 18, 39, 262544, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.atime
datetime.datetime(2019, 9, 20, 7, 18, 39, 263453, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.expiry_time
datetime.datetime(2019, 9, 20, 7, 18, 39, 263453, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
```

KDBX V4
```
>>> from pykeepass import PyKeePass
>>> database = 'test4.kdbx'
>>> password = 'password'
>>> keyfile = 'test4.key'
>>> kp = PyKeePass(database, password=password, keyfile=keyfile)
>>> 
>>> from datetime import datetime, timedelta
>>> from dateutil import tz
>>> from pykeepass.entry import Entry
>>> now = datetime.now(tz.gettz())
>>> utc = datetime.now(tz.gettz('UTC'))
>>> entry = Entry(
...     'title',
...     'username',
...     'password',
...     kp=kp
... )
>>> 
>>> now
datetime.datetime(2019, 9, 20, 9, 20, 33, 422343, tzinfo=tzfile('/etc/localtime'))
>>> utc
datetime.datetime(2019, 9, 20, 7, 20, 33, 422696, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.atime
datetime.datetime(2019, 9, 20, 7, 20, 33, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
>>> entry.expiry_time
datetime.datetime(2019, 9, 20, 7, 20, 33, tzinfo=tzfile('/usr/share/zoneinfo/UTC'))
```
