### PR TITLE
Remove logging initialization with default values

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -25,7 +25,6 @@ from pykeepass.kdbx_parsing.kdbx import KDBX
 from pykeepass.kdbx_parsing.kdbx4 import kdf_uuids
 from pykeepass.xpath import attachment_xp, entry_xp, group_xp, path_xp
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Initialization will overwrite other project calls to logging basicConfig