### PR TITLE
Fixes a issue with trailing bytes after xml in database files.

### DIFF
--- a/pykeepass/kdbx_parsing/common.py
+++ b/pykeepass/kdbx_parsing/common.py
@@ -165,7 +165,15 @@ class XML(Adapter):
     """Bytes <---> lxml etree"""
 
     def _decode(self, data, con, path):
-        return etree.parse(BytesIO(data))
+        # Convert data to utf-8 string
+        xml_and_maybe_more = data.decode('utf-8')
+        # Find the last > to cut any bytes after the xml
+        xml_end_pos = xml_and_maybe_more.rfind('>') + 1
+        # Cut at the xml end position
+        xml = xml_and_maybe_more[:xml_end_pos]
+        # Convert back to bytes
+        bdata = bytes(xml, encoding='utf-8')
+        return etree.parse(BytesIO(bdata))
 
     def _encode(self, tree, con, path):
         return etree.tostring(tree)


### PR DESCRIPTION
For some reason, some database files I've encountered has trailing bytes after the xml. In the last case it was b'\x06\x06\x06\x06\x06\x06' which still was read fine by most keepass applications (keepass, keeweb, etc), but which failed to load with this python library. 

The patch removes any trailing bytes from the xml before attempting to parse the xml.
