### PR TITLE
Add documentation to ReadTheDocs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/doc/source/attachment.rst
+++ b/doc/source/attachment.rst
@@ -1,0 +1,5 @@
+attachment
+==========
+
+.. automodule:: pykeepass.attachment
+   :members:

--- a/doc/source/baseelement.rst
+++ b/doc/source/baseelement.rst
@@ -1,0 +1,5 @@
+baseelement
+===========
+
+.. automodule:: pykeepass.baseelement
+   :members:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,3 +49,4 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+master_doc = 'index'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'PyKeePass'
+copyright = '2020, -'
+author = '-'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -27,8 +27,7 @@ author = '-'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ['sphinx.ext.autodoc']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/entry.rst
+++ b/doc/source/entry.rst
@@ -1,0 +1,5 @@
+entry
+=====
+
+.. automodule:: pykeepass.entry
+   :members:

--- a/doc/source/exceptions.rst
+++ b/doc/source/exceptions.rst
@@ -1,0 +1,5 @@
+exceptions
+==========
+
+.. automodule:: pykeepass.exceptions
+   :members:

--- a/doc/source/group.rst
+++ b/doc/source/group.rst
@@ -1,0 +1,5 @@
+group
+=====
+
+.. automodule:: pykeepass.group
+   :members:

--- a/doc/source/icons.rst
+++ b/doc/source/icons.rst
@@ -1,0 +1,5 @@
+icons
+=====
+
+.. automodule:: pykeepass.icons
+   :members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -365,7 +365,7 @@ create a new database at ``filename`` with supplied credentials.  Returns ``PyKe
 Tests
 -----
 
-To run them issue :code:`python tests/tests.py`
+To run them issue :code:`python -m unittest discover` in the repository.
 
 Indices and tables
 ==================

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,0 +1,20 @@
+.. PyKeePass documentation master file, created by
+   sphinx-quickstart on Sun Oct  4 23:48:57 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to PyKeePass's documentation!
+=====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,15 +1,19 @@
-.. PyKeePass documentation master file, created by
-   sphinx-quickstart on Sun Oct  4 23:48:57 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to PyKeePass's documentation!
-=====================================
+PyKeePass
+=========
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
+   :glob:
 
+   pykeepass
+   group
+   entry
+   attachment
+   icons
+   exceptions
+   baseelement
+   kdbx_parsing/*
 
 
 Indices and tables

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,7 +3,7 @@ PyKeePass
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :hidden:
    :glob:
 
    pykeepass

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,6 +15,357 @@ PyKeePass
    baseelement
    kdbx_parsing/*
 
+.. image:: https://travis-ci.org/libkeepass/pykeepass.svg?branch=master
+   :target: https://travis-ci.org/libkeepass/pykeepass
+
+.. image:: https://img.shields.io/matrix/pykeepass:matrix.org.svg
+   :target: https://matrix.to/#/#pykeepass:matrix.org
+
+
+This library allows you to write entries to a KeePass database.
+
+Come chat at `#pykeepass`_ on Freenode or `#pykeepass:matrix.org`_ on Matrix.
+
+.. _#pykeepass: irc://irc.freenode.net
+.. _#pykeepass\:matrix.org: https://matrix.to/#/%23pykeepass:matrix.org
+
+Example
+-------
+
+.. code:: python
+
+   from pykeepass import PyKeePass
+
+   # load database
+   >>> kp = PyKeePass('db.kdbx', password='somePassw0rd')
+
+   # find any group by its name
+   >>> group = kp.find_groups(name='social', first=True)
+
+   # get the entries in a group
+   >>> group.entries
+   [Entry: "social/facebook (myusername)", Entry: "social/twitter (myusername)"]
+
+   # find any entry by its title
+   >>> entry = kp.find_entries(title='facebook', first=True)
+
+   # retrieve the associated password
+   >>> entry.password
+   's3cure_p455w0rd'
+
+   # update an entry
+   >>> entry.notes = 'primary facebook account'
+
+   # create a new group
+   >>> group = kp.add_group(kp.root_group, 'email')
+
+   # create a new entry
+   >>> kp.add_entry(group, 'gmail', 'myusername', 'myPassw0rdXX')
+   Entry: "email/gmail (myusername)"
+
+   # save database
+   >>> kp.save()
+
+
+Finding Entries
+---------------
+
+**find_entries** (title=None, username=None, password=None, url=None, notes=None, path=None, uuid=None, tags=None, string=None, group=None, recursive=True, regex=False, flags=None, history=False, first=False)
+
+Returns entries which match all provided parameters, where ``title``, ``username``, ``password``, ``url``, ``notes``, ``path``, and ``autotype_sequence`` are strings, ``string`` is a dict, ``autotype_enabled`` is a boolean, ``uuid`` is a ``uuid.UUID`` and ``tags`` is a list of strings.  This function has optional ``regex`` boolean and ``flags`` string arguments, which means to interpret search strings as `XSLT style`_ regular expressions with `flags`_.
+
+.. _XSLT style: https://www.xml.com/pub/a/2003/06/04/tr.html
+.. _flags: https://www.w3.org/TR/xpath-functions/#flags
+
+The ``path`` string is a full path to an entry (ex. ``'foobar_group/foobar_entry'``).  This implies ``first=True``.  All other arguments are ignored when this is given.  This is useful for handling user input.
+
+The ``string`` dict allows for searching custom string fields.  ex. ``{'custom_field1': 'custom value', 'custom_field2': 'custom value'}``
+
+The ``group`` argument determines what ``Group`` to search under, and the ``recursive`` boolean controls whether to search recursively.
+
+The ``history`` (default ``False``) boolean controls whether history entries should be included in the search results.
+
+The ``first`` (default ``False``) boolean controls whether to return the first matched item, or a list of matched items.
+
+* if ``first=False``, the function returns a list of ``Entry`` s or ``[]`` if there are no matches
+* if ``first=True``, the function returns the first ``Entry`` match, or ``None`` if there are no matches
+
+**entries**
+
+a flattened list of all entries in the database
+
+.. code:: python
+
+   >>> kp.entries
+   [Entry: "foo_entry (myusername)", Entry: "foobar_entry (myusername)", Entry: "social/gmail (myusername)", Entry: "social/facebook (myusername)"]
+
+   >>> kp.find_entries(title='gmail', first=True)
+   Entry: "social/gmail (myusername)"
+
+   >>> kp.find_entries(title='foo.*', regex=True)
+   [Entry: "foo_entry (myusername)", Entry: "foobar_entry (myusername)"]
+
+   >>> entry = kp.find_entries(title='foo.*', url='.*facebook.*', regex=True, first=True)
+   >>> entry.url
+   'facebook.com'
+   >>> entry.title
+   'foo_entry'
+
+   >>> group = kp.find_group(name='social', first=True)
+   >>> kp.find_entries(title='facebook', group=group, recursive=False, first=True)
+   Entry: "social/facebook (myusername)"
+
+
+Finding Groups
+--------------
+
+**find_groups** (name=None, path=None, uuid=None, notes=None, group=None, recursive=True, regex=False, flags=None, first=False)
+
+where ``name``, ``path``, and ``notes`` are strings, ``uuid`` is a ``uuid.UUID``. This function has optional ``regex`` boolean and ``flags`` string arguments, which means to interpret search strings as `XSLT style`_ regular expressions with `flags`_.
+
+.. _XSLT style: https://www.xml.com/pub/a/2003/06/04/tr.html
+.. _flags: https://www.w3.org/TR/xpath-functions/#flags
+
+The ``path`` string is a full path to a group (ex. ``'foobar_group/sub_group'``).  This implies ``first=True``.  All other arguments are ignored when this is given.  This is useful for handling user input.
+
+The ``group`` argument determines what ``Group`` to search under, and the ``recursive`` boolean controls whether to search recursively.
+
+The ``first`` (default ``False``) boolean controls whether to return the first matched item, or a list of matched items.
+
+* if ``first=False``, the function returns a list of ``Group`` s or ``[]`` if there are no matches
+* if ``first=True``, the function returns the first ``Group`` match, or ``None`` if there are no matches
+
+**root_group**
+
+the ``Root`` group to the database
+
+**groups**
+
+a flattened list of all groups in the database
+
+.. code:: python
+
+   >>> kp.groups
+   [Group: "foo", Group "foobar", Group: "social", Group: "social/foo_subgroup"]
+
+   >>> kp.find_groups(name='foo', first=True)
+   Group: "foo"
+
+   >>> kp.find_groups(name='foo.*', regex=True)
+   [Group: "foo", Group "foobar"]
+
+   >>> kp.find_groups(path='social/', regex=True)
+   [Group: "social", Group: "social/foo_subgroup"]
+
+   >>> kp.find_groups(name='social', first=True).subgroups
+   [Group: "social/foo_subgroup"]
+
+   >>> kp.root_group
+   Group: "/"
+
+
+Adding Entries
+--------------
+
+**add_entry** (destination_group, title, username, password, url=None, notes=None, tags=None, expiry_time=None, icon=None, force_creation=False)
+
+**delete_entry** (entry)
+
+**move_entry** (entry, destination_group)
+
+where ``destination_group`` is a ``Group`` instance.  ``entry`` is an ``Entry`` instance. ``title``, ``username``, ``password``, ``url``, ``notes``, ``tags``, ``icon`` are strings. ``expiry_time`` is a ``datetime`` instance.
+
+If ``expiry_time`` is a naive datetime object (i.e. ``expiry_time.tzinfo`` is not set), the timezone is retrieved from ``dateutil.tz.gettz()``.
+
+.. code:: python
+
+   # add a new entry to the Root group
+   >>> kp.add_entry(kp.root_group, 'testing', 'foo_user', 'passw0rd')
+   Entry: "testing (foo_user)"
+
+   # add a new entry to the social group
+   >>> group = find_groups(name='social', first=True)
+   >>> entry = kp.add_entry(group, 'testing', 'foo_user', 'passw0rd')
+   Entry: "testing (foo_user)"
+
+   # save the database
+   >>> kp.save()
+
+   # delete an entry
+   >>> kp.delete_entry(entry)
+
+   # move an entry
+   >>> kp.move_entry(entry, kp.root_group)
+
+   # save the database
+   >>> kp.save()
+
+Adding Groups
+--------------
+
+**add_group** (destination_group, group_name, icon=None, notes=None)
+
+**delete_group** (group)
+
+**move_group** (group, destination_group)
+
+``destination_group`` and ``group`` are instances of ``Group``.  ``group_name`` is a string
+
+.. code:: python
+
+   # add a new group to the Root group
+   >>> group = kp.add_group(kp.root_group, 'social')
+
+   # add a new group to the social group
+   >>> group2 = kp.add_group(group, 'gmail')
+   Group: "social/gmail"
+
+   # save the database
+   >>> kp.save()
+
+   # delete a group
+   >>> kp.delete_group(group)
+
+   # move a group
+   >>> kp.move_group(group2, kp.root_group)
+
+   # save the database
+   >>> kp.save()
+
+Attachments
+-----------
+
+In this section, *binary* refers to the bytes of the attached data (stored at the root level of the database), while *attachment* is a reference to a binary (stored in an entry).  A binary can have none, one or many attachments.
+
+**add_binary** (data, compressed=True, protected=True)
+
+where ``data`` is bytes.  Adds a blob of data to the database. The attachment reference must still be added to an entry (see below).  ``compressed`` only applies to KDBX3 and ``protected`` only applies to KDBX4.  Returns id of attachment.
+
+**delete_binary** (id)
+
+where ``id`` is an int.  Removes binary data from the database and deletes any attachments that reference it.  Since attachments reference binaries by their positional index, attachments that reference binaries with id > ``id`` will automatically be decremented.
+
+**find_attachments** (id=None, filename=None, element=None, recursive=True, regex=False, flags=None, history=False, first=False)
+
+where ``id`` is an int, ``filename`` is a string, and element is an ``Entry`` or ``Group`` to search under.
+
+* if ``first=False``, the function returns a list of ``Attachment`` s or ``[]`` if there are no matches
+* if ``first=True``, the function returns the first ``Attachment`` match, or ``None`` if there are no matches
+
+**binaries**
+
+list of bytestrings containing binary data.  List index corresponds to attachment id.
+
+**attachments**
+
+list containing all ``Attachment`` s in the database.
+
+**Entry.add_attachment** (id, filename)
+
+where ``id`` is an int and ``filename`` is a string.  Creates a reference using the given filename to a database binary.  The existence of a binary with the given id is not checked.  Returns ``Attachment``.
+
+**Entry.delete_attachment** (attachment)
+
+where ``attachment`` is an ``Attachment``.  Deletes a reference to a database binary.
+
+**Entry.attachments**
+
+list of ``Attachment`` s for this Entry.
+
+**Attachment.id**
+
+id of data that this attachment points to
+
+**Attachment.filename**
+
+string representing this attachment
+
+**Attachment.data**
+
+the data that this attachment points to.  Raises ``BinaryError`` if data does not exist.
+
+**Attachment.entry**
+
+the entry that this attachment is attached to
+
+.. code:: python
+
+   >>> e = kp.add_entry(kp.root_group, title='foo', username='', password='')
+
+   # add attachment data to the db
+   >>> binary_id = kp.add_binary(b'Hello world')
+
+   >>> kp.binaries
+   [b'Hello world']
+
+   # add attachment reference to entry
+   >>> a = e.add_attachment(binary_id, 'hello.txt')
+   >>> a
+   Attachment: 'hello.txt' -> 0
+
+   # access attachments
+   >>> a
+   Attachment: 'hello.txt' -> 0
+   >>> a.id
+   0
+   >>> a.filename
+   'hello.txt'
+   >>> a.data
+   b'Hello world'
+   >>> e.attachments
+   [Attachment: 'hello.txt' -> 0]
+
+   # list all attachments in the database
+   >>> kp.attachments
+   [Attachment: 'hello.txt' -> 0]
+
+   # search attachments
+   >>> kp.find_attachments(filename='hello.txt')
+   [Attachment: 'hello.txt' -> 0]
+
+   # delete attachment reference
+   >>> e.delete_attachment(a)
+
+   # or, delete both attachment reference and binary
+   >>> kp.delete_binary(binary_id)
+
+Miscellaneous
+-------------
+
+**read** (filename=None, password=None, keyfile=None, transformed_key=None)
+
+where ``filename``, ``password``, and ``keyfile`` are strings.  ``filename`` is the path to the database, ``password`` is the master password string, and ``keyfile`` is the path to the database keyfile.  At least one of ``password`` and ``keyfile`` is required.  Alternatively, the derived key can be supplied directly through ``transformed_key``.
+
+Can raise ``CredentialsError``, ``HeaderChecksumError``, or ``PayloadChecksumError``.
+
+**save** (filename=None)
+
+where ``filename`` is the path of the file to save to.  If ``filename`` is not given, the path given in ``read`` will be used.
+
+**password**
+
+string containing database password.  Can also be set.  Use ``None`` for no password.
+
+**keyfile**
+
+string containing path to the database keyfile.  Can also be set.  Use ``None`` for no keyfile.
+
+**version**
+
+tuple containing database version.  e.g. ``(3, 1)`` is a KDBX version 3.1 database.
+
+**encryption_algorithm**
+
+string containing algorithm used to encrypt database.  Possible values are ``aes256``, ``chacha20``, and ``twofish``.
+
+**create_database** (filename, password=None, keyfile=None, transformed_key=None)
+
+create a new database at ``filename`` with supplied credentials.  Returns ``PyKeePass`` object
+
+Tests
+-----
+
+To run them issue :code:`python tests/tests.py`
 
 Indices and tables
 ==================

--- a/doc/source/kdbx_parsing/common.rst
+++ b/doc/source/kdbx_parsing/common.rst
@@ -1,0 +1,5 @@
+kdbx_parsing.common
+===================
+
+.. automodule:: pykeepass.kdbx_parsing.common
+   :members:

--- a/doc/source/kdbx_parsing/kdbx.rst
+++ b/doc/source/kdbx_parsing/kdbx.rst
@@ -1,0 +1,5 @@
+kdbx_parsing.kdbx
+=================
+
+.. automodule:: pykeepass.kdbx_parsing.kdbx
+   :members:

--- a/doc/source/kdbx_parsing/kdbx3.rst
+++ b/doc/source/kdbx_parsing/kdbx3.rst
@@ -1,0 +1,5 @@
+kdbx_parsing.kdbx3
+==================
+
+.. automodule:: pykeepass.kdbx_parsing.kdbx3
+   :members:

--- a/doc/source/kdbx_parsing/kdbx4.rst
+++ b/doc/source/kdbx_parsing/kdbx4.rst
@@ -1,0 +1,5 @@
+kdbx_parsing.kdbx4
+==================
+
+.. automodule:: pykeepass.kdbx_parsing.kdbx4
+   :members:

--- a/doc/source/kdbx_parsing/pytwofish.rst
+++ b/doc/source/kdbx_parsing/pytwofish.rst
@@ -1,0 +1,5 @@
+kdbx_parsing.pytwofish
+======================
+
+.. automodule:: pykeepass.kdbx_parsing.pytwofish
+   :members:

--- a/doc/source/kdbx_parsing/twofish.rst
+++ b/doc/source/kdbx_parsing/twofish.rst
@@ -1,0 +1,5 @@
+kdbx_parsing.twofish
+====================
+
+.. automodule:: pykeepass.kdbx_parsing.twofish
+   :members:

--- a/doc/source/pykeepass.rst
+++ b/doc/source/pykeepass.rst
@@ -1,0 +1,5 @@
+pykeepass
+=========
+
+.. automodule:: pykeepass.pykeepass
+   :members:

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -1,0 +1,7 @@
+lxml==4.3.5
+pycryptodomex==3.9.4
+construct==2.10.54
+argon2-cffi==19.2.0
+python-dateutil==2.8.0
+future==0.17.1
+Sphinx>=3.2.1


### PR DESCRIPTION
Copies README.rst + adds basic structure + `automodule` for each module except `xpath` (seems like a file with constants only).

Documentation is here: https://pykeepass.readthedocs.io/en/latest/, currently built from my `rtd` branch. Create accounts on RTD so I can give you maintainer access. :yum: 

Closes #111