### PR TITLE
[WIP] use elementpath for finding via XPath (2.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ construct==2.10.54
 argon2-cffi==19.2.0
 python-dateutil==2.8.0
 future==0.17.1
+elementpath==2.0.3

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -750,6 +750,34 @@ class BugRegressionTests3(KDBX3Tests):
         self.assertTrue(g.name is None)
         self.assertTrue(g in self.kp.groups)
 
+    def test_issue123(self):
+        # issue 193 - kp.entries can't contain quotes or apostrophes
+        entries = [
+            self.kp.add_entry(
+                self.kp.root_group, 'te"st', 'user"', 'single"'
+            ),
+            self.kp.add_entry(
+                self.kp.root_group, 'te""st', 'user""', 'double"'
+            ),
+            self.kp.add_entry(
+                self.kp.root_group, "te'st", "user'", "single'"
+            ),
+            self.kp.add_entry(
+                self.kp.root_group, "te''st", "user''", "double''"
+            )
+        ]
+        for entry in entries:
+            self.assertTrue(entry.title is not None)
+            self.assertTrue(entry in self.kp.entries)
+
+        for entry in entries:
+            temp = self.kp.find_entries(title=entry.title)
+            self.assertIsInstance(temp, list)
+            self.assertEqual(len(temp), 1)
+            temp = temp[0]
+            self.assertEqual(temp.title, entry.title)
+            self.assertEqual(temp.username, entry.username)
+            self.assertEqual(temp.password, entry.password)
 
 
 class EntryFindTests4(KDBX4Tests, EntryFindTests3):


### PR DESCRIPTION
The problem is that [`lxml` uses XPath 1.0](https://stackoverflow.com/a/53195682/5994041). That version does not know [how to escape](https://stackoverflow.com/a/12406443/5994041) those characters as those are [special/forbidden](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML). Instead, we can use [`elementpath`](https://github.com/sissaschool/elementpath) which seems to be quite popular (among other XPath 2.0 related packages), but it breaks the tests.

For XPath 1.0 fixing #123 doesn't seem possible, so perhaps rewriting everything to `elementpath.select(root, path)` would work if the rest of the codebase was adjusted as well.

Closes #123 