### PR TITLE
Add badges for IRC channel and RTD build status

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ pykeepass
 .. image:: https://img.shields.io/matrix/pykeepass:matrix.org.svg
    :target: https://matrix.to/#/#pykeepass:matrix.org
 
+.. image:: https://img.shields.io/badge/irc-%23pykeepass-brightgreen
+   :target: https://webchat.freenode.net/?channels=pykeepass
     
 This library allows you to write entries to a KeePass database.
 

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,10 @@ pykeepass
 .. image:: https://travis-ci.org/libkeepass/pykeepass.svg?branch=master
    :target: https://travis-ci.org/libkeepass/pykeepass
 
+.. image:: https://readthedocs.org/projects/pykeepass/badge/?version=latest
+   :target: https://pykeepass.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
 .. image:: https://img.shields.io/matrix/pykeepass:matrix.org.svg
    :target: https://matrix.to/#/#pykeepass:matrix.org
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,6 +21,8 @@ PyKeePass
 .. image:: https://img.shields.io/matrix/pykeepass:matrix.org.svg
    :target: https://matrix.to/#/#pykeepass:matrix.org
 
+.. image:: https://img.shields.io/badge/irc-%23pykeepass-brightgreen
+   :target: https://webchat.freenode.net/?channels=pykeepass
 
 This library allows you to write entries to a KeePass database.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,6 +18,10 @@ PyKeePass
 .. image:: https://travis-ci.org/libkeepass/pykeepass.svg?branch=master
    :target: https://travis-ci.org/libkeepass/pykeepass
 
+.. image:: https://readthedocs.org/projects/pykeepass/badge/?version=latest
+   :target: https://pykeepass.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status
+
 .. image:: https://img.shields.io/matrix/pykeepass:matrix.org.svg
    :target: https://matrix.to/#/#pykeepass:matrix.org
 


### PR DESCRIPTION
For IRC it also gives an online client provided directly by Freenode so there's no need to install anything (same as with Matrix).