### PR TITLE
Basic CLI

### DIFF
--- a/doc/source/__main__.rst
+++ b/doc/source/__main__.rst
@@ -1,0 +1,5 @@
+__main__
+========
+
+.. automodule:: pykeepass.__main__
+   :members:

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -14,6 +14,7 @@ PyKeePass
    exceptions
    baseelement
    kdbx_parsing/*
+   __main__
 
 .. image:: https://travis-ci.org/libkeepass/pykeepass.svg?branch=master
    :target: https://travis-ci.org/libkeepass/pykeepass
@@ -367,6 +368,36 @@ string containing algorithm used to encrypt database.  Possible values are ``aes
 **create_database** (filename, password=None, keyfile=None, transformed_key=None)
 
 create a new database at ``filename`` with supplied credentials.  Returns ``PyKeePass`` object
+
+Console usage (CLI)
+-------------------
+
+PyKeePass allows you to manipulate KeePass database straight from the console
+via simple set of commands:
+
+.. code:: shell
+
+   # display help
+   $ pykeepass --help
+
+   # show all items as a tree in CLI
+   $ pykeepass -p password -f ~/Desktop/mydatabase.kdbx tree
+   [Root]
+   |-- [foobar_group]
+   |   |-- [subgroup/name]
+   |   |   |-- subentry
+   |   |   |-- subentry2
+   |   |   `-- foobar_entry
+   |   |
+   |   |-- group_entry
+   |   `-- foobar_entry
+   |
+   |-- [foobar_group2]
+   |-- [Работа]
+   |   `-- Тест
+   |
+   |-- root_entry
+   `-- test/name
 
 Tests
 -----

--- a/pykeepass/__main__.py
+++ b/pykeepass/__main__.py
@@ -1,0 +1,2 @@
+def main():
+    print("this is main")

--- a/pykeepass/__main__.py
+++ b/pykeepass/__main__.py
@@ -1,2 +1,8 @@
+from argparse import ArgumentParser
+from pykeepass import __version__
+
+
 def main():
-    print("this is main")
+    parser = ArgumentParser()
+    parser.add_argument("--version", action="version", version=__version__)
+    parser.parse_args()

--- a/pykeepass/__main__.py
+++ b/pykeepass/__main__.py
@@ -1,8 +1,133 @@
-from argparse import ArgumentParser
-from pykeepass import __version__
+"""
+Main module for CLI entrypoint handling all of the provided arguments and
+subparser contexts to enable usage of PyKeePass as a standalone KeePass CLI
+manager.
+"""
+
+from argparse import ArgumentParser, Namespace
+from pykeepass import __version__, PyKeePass
+from pykeepass.group import Group
+
+SUBPARSER_TREE = "tree"
+INDENT_WIDTH = 4
+GROUP_BEGIN = "["
+GROUP_END = "]"
+TREE_HANDLE = "|"
+TREE_HANDLE_END = "`"
+TREE_TICK = "-- "
+
+
+def generate_padding(indent: int) -> str:
+    """Generate padding with tree handles (lines) on each indent."""
+    len_pad = INDENT_WIDTH * indent
+    padding = " " * len_pad
+    if not padding:
+        return padding  # empty string
+
+    for idx in range(len_pad):
+        if idx % INDENT_WIDTH != 0:
+            continue
+        # slice on every width's occasion and insert tree handle
+        padding = padding[:idx] + TREE_HANDLE + padding[idx + 1:]
+    return padding
+
+
+def print_tree_children(
+        children: list, padding: str, tree_iteration: int, tree_length: int,
+        root: bool = False
+):
+    """Print group's children as a part of a parent tree."""
+    len_children = len(children)
+    for idx, item in enumerate(children):
+        if idx == len_children - 1:
+            print(padding + TREE_HANDLE_END + TREE_TICK + item)
+            if tree_iteration < tree_length - 1:
+                print()
+            else:
+                if not root:
+                    print(padding)
+        else:
+            print(padding + TREE_HANDLE + TREE_TICK + item)
+
+
+def print_tree(tree: dict, indent: int = 0, root: bool = False):
+    """
+    Handles all the fancy brackets, pipes, backticks, and ticks that make
+    the visual tree out of ASCII in a console.
+    """
+    padding = generate_padding(indent=indent)
+
+    tree_items = tree.items()
+    len_tree = len(tree_items)
+    for tidx, packed in enumerate(tree_items):
+        title, values = packed
+
+        group_prefix = padding
+        if not root:
+            group_prefix = padding[:-INDENT_WIDTH] + TREE_HANDLE + TREE_TICK
+        print(group_prefix + f"{GROUP_BEGIN}{title}{GROUP_END}")
+        groups = values["groups"]
+        items = values["items"]
+
+        for group in groups:
+            print_tree(group, indent=indent + 1)
+
+        print_tree_children(
+            children=items, padding=padding, tree_iteration=tidx,
+            tree_length=len_tree, root=root
+        )
+
+
+def collect_groups(group: Group) -> dict:
+    """
+    Collect group names and names of their children (entries) as a tree-like
+    structure for easier printing.
+    """
+    result = {}
+    name = group.name
+    if name not in result:
+        result[name] = {"groups": [], "items": [
+            entry.title for entry in group.entries
+        ]}
+
+        for child in group.subgroups:
+            result[name]["groups"].append(collect_groups(child))
+    return result
+
+
+def show_tree(
+        filename: str, password: str, keyfile=None, transformed_key=None
+):
+    """Command for showing the KDBX as a tree in a console."""
+    kdbx = PyKeePass(
+        filename=filename, password=password,
+        keyfile=keyfile, transformed_key=transformed_key
+    )
+    tree = collect_groups(kdbx.root_group)
+    print_tree(tree, root=True)
+
+
+def handle_commands(args: Namespace):
+    """Handler for specific subparsers and their code branches."""
+    if args.subparser == SUBPARSER_TREE:
+        show_tree(
+            filename=args.file, password=args.password,
+            keyfile=args.keyfile, transformed_key=args.transformed_key
+        )
 
 
 def main():
+    """Main function for the CLI entrypoint."""
     parser = ArgumentParser()
     parser.add_argument("--version", action="version", version=__version__)
-    parser.parse_args()
+    parser.add_argument("-p", "--password", required=True)
+    parser.add_argument("-f", "--file", required=True)
+    parser.add_argument("-k", "--keyfile", required=False)
+    parser.add_argument("-t", "--transformed-key", required=False)
+
+    sub = parser.add_subparsers(dest="subparser")
+    sub = sub.add_parser(SUBPARSER_TREE, help="display KDBX items as a tree")
+
+    args = parser.parse_args()
+
+    handle_commands(args)

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ from pykeepass import __version__
 with open("README.rst") as file:
     README = file.read()
 
+NAME = "pykeepass"
 setup(
-    name="pykeepass",
+    name=NAME,
     version=__version__,
     license="GPL3",
     description="Python library to interact with keepass databases "
@@ -13,7 +14,7 @@ setup(
     long_description=README,
     author="Philipp Schmitt",
     author_email="philipp@schmitt.co",
-    url="https://github.com/pschmitt/pykeepass",
+    url=f"https://github.com/libkeepass/{NAME}",
     packages=find_packages(),
     install_requires=[
         "python-dateutil",
@@ -25,5 +26,6 @@ setup(
         # FIXME python2
         "future"
     ],
-    include_package_data=True
+    include_package_data=True,
+    entry_points={'console_scripts': [f'{NAME} = {NAME}.__main__:main']}
 )


### PR DESCRIPTION
Issue #205 made me thinking about the current usage and basically we have the API/backend ready, but there's an opportunity to take with missing frontend. For that we can use `argparse` and create a basic set of commands for managing kdbx from CLI. This will bring wider audience to the library especially if we'd create a PPA for Debian-based distros and provide a binary for Windows + MacOS.

It's not meant as a full standalone KeePass client as with other GUIs (although if we find a client to auto-type, it might work that way too), but as a quick tool for various bulk automation or for migration between password managers without knowing Python itself (e.g. just use bash).

Example:

```shell
$ pykeepass -p password -f ~/Desktop/mydatabase.kdbx tree
[Root]
|-- [foobar_group]
|   |-- [subgroup/name]
|   |   |-- subentry
|   |   |-- subentry2
|   |   `-- foobar_entry
|   |
|   |-- group_entry
|   `-- foobar_entry
|
|-- [foobar_group2]
|-- [Работа]
|   `-- Тест
|
|-- root_entry
`-- test/name
```

Closes #205, at least I think it'd be sufficient based on [this comment](https://github.com/libkeepass/pykeepass/issues/205#issuecomment-706529282).