### PR TITLE
Save to temporary file

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -8,6 +8,7 @@ import base64
 import logging
 import os
 import re
+import shutil
 import uuid
 import zlib
 from copy import deepcopy
@@ -132,12 +133,12 @@ class PyKeePass(object):
             transformed_key (:obj:`bytes`, optional): precomputed transformed
                 key.
         """
-        output = None
+
         if not filename:
             filename = self.filename
 
         if hasattr(filename, "write"):
-            output = KDBX.build_stream(
+            KDBX.build_stream(
                 self.kdbx,
                 filename,
                 password=self.password,
@@ -145,14 +146,21 @@ class PyKeePass(object):
                 transformed_key=transformed_key
             )
         else:
-            output = KDBX.build_file(
-                self.kdbx,
-                filename,
-                password=self.password,
-                keyfile=self.keyfile,
-                transformed_key=transformed_key
-            )
-        return output
+            # save to temporary file to prevent database clobbering
+            # see issues 223, 101
+            # FIXME python2 - use pathlib.Path.withsuffix
+            filename_tmp = filename + '.tmp'
+            try:
+                KDBX.build_file(
+                    self.kdbx,
+                    filename_tmp,
+                    password=self.password,
+                    keyfile=self.keyfile,
+                    transformed_key=transformed_key
+                )
+            except Exception as e:
+                os.remove(filename_tmp)
+            shutil.move(filename_tmp, filename)
 
     @property
     def version(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -648,7 +648,7 @@ class GroupTests3(KDBX3Tests):
 class AttachmentTests3(KDBX3Tests):
     # get some things ready before testing
     def setUp(self):
-        super(AttachmentTests3, self).tearDown()
+        super(AttachmentTests3, self).setUp()
         shutil.copy(
             os.path.join(base_dir, self.database),
             os.path.join(base_dir, 'test_attachment.kdbx')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -648,7 +648,7 @@ class GroupTests3(KDBX3Tests):
 class AttachmentTests3(KDBX3Tests):
     # get some things ready before testing
     def setUp(self):
-        super().setUp()
+        super(AttachmentTests3, self).tearDown()
         shutil.copy(
             os.path.join(base_dir, self.database),
             os.path.join(base_dir, 'test_attachment.kdbx')
@@ -704,7 +704,7 @@ class AttachmentTests3(KDBX3Tests):
         self.assertEqual(a.filename, 'test.txt')
 
     def tearDown(self):
-        super().tearDown()
+        super(AttachmentTests3, self).tearDown()
         os.remove(os.path.join(base_dir, 'test_attachment.kdbx'))
 
 
@@ -765,7 +765,7 @@ class BugRegressionTests3(KDBX3Tests):
 
         # change keyfile so database save fails
         self.kp_tmp.keyfile = 'foo'
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(Exception):
             self.kp_tmp.save()
 
         # try to open database


### PR DESCRIPTION
Save to `database.kdbx.tmp`, then move over `database.kdbx` to prevent database clobbering if there is an exception.