### PR TITLE
Allow using pycryptodome alternatively

### DIFF
--- a/pykeepass/kdbx_parsing/common.py
+++ b/pykeepass/kdbx_parsing/common.py
@@ -1,6 +1,11 @@
-from Cryptodome.Cipher import AES, ChaCha20, Salsa20
+# support both pycryptodomex (Cryptodome) and pycryptodome (Crypto)
+try:
+    from Cryptodome.Cipher import AES, ChaCha20, Salsa20
+    from Cryptodome.Util import Padding as CryptoPadding
+except ImportError:
+    from Crypto.Cipher import AES, ChaCha20, Salsa20
+    from Crypto.Util import Padding as CryptoPadding
 from .twofish import Twofish
-from Cryptodome.Util import Padding as CryptoPadding
 import hashlib
 from construct import (
     Adapter, BitStruct, BitsSwapped, Container, Flag, Padding, ListContainer, Mapping, GreedyBytes, Int32ul, Switch

--- a/pykeepass/kdbx_parsing/twofish.py
+++ b/pykeepass/kdbx_parsing/twofish.py
@@ -25,8 +25,13 @@
 __all__ = ['Twofish']
 
 from . import pytwofish
-from Cryptodome.Util.strxor import strxor
-from Cryptodome.Util.Padding import pad
+# support both pycryptodomex (Cryptodome) and pycryptodome (Crypto)
+try:
+    from Cryptodome.Util.strxor import strxor
+    from Cryptodome.Util.Padding import pad
+except ImportError:
+    from Crypto.Util.Padding import pad
+    from Crypto.Util.strxor import strxor
 
 MODE_ECB = 1
 MODE_CBC = 2
@@ -149,7 +154,7 @@ class BlockCipher():
         """
         #self.ed = 'e' if chain is encrypting, 'd' if decrypting,
         # None if nothing happened with the chain yet
-        #assert self.ed in ('e',None) 
+        #assert self.ed in ('e',None)
         # makes sure you don't encrypt with a cipher that has started decrypting
         self.ed = 'e'
         if self.mode == MODE_XTS:
@@ -291,7 +296,7 @@ class python_Twofish(BlockCipher):
         cipher_module = pytwofish.Twofish
         self.blocksize = 16
         BlockCipher.__init__(self,key,mode,IV,counter,cipher_module,segment_size)
-    
+
     @classmethod
     def new(cls, key,mode=MODE_ECB,IV=None,counter=None,segment_size=None):
         return cls(key,mode,IV,counter,segment_size)


### PR DESCRIPTION
Hi,

As of late gentoo has deprecated pycryptodomex, because they refuse to keep the same package around twice (https://github.com/gentoo/gentoo/commit/58d1a1ddba4d5834337df0fe684d20792709d39c#diff-e44de67df9ef089ce413d3b684a23f98d1631e3202ee7512b769d8e6a55be76a). It would be cool if pykeepass could use either of them as dependency.

This commit changes the import to try load pycryptodomex first and fall back to pycryptodome.

Greetings, Anton