### PR TITLE
Support for custom icons

### DIFF
--- a/pykeepass/custom_icon.py
+++ b/pykeepass/custom_icon.py
@@ -1,0 +1,45 @@
+# FIXME python2
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import absolute_import
+from future.utils import python_2_unicode_compatible
+
+import uuid;
+import base64;
+
+import pykeepass.entry
+
+# FIXME python2
+@python_2_unicode_compatible
+class CustomIcon(object):
+    def __init__(self, element, kp=None):
+        self._element = element
+        self._kp = kp
+
+    def __repr__(self):
+        return "CustomIcon: '{}'".format(self.uuid)
+
+    @property
+    def uuid(self):
+        field = self._element.find('UUID')
+        if field is not None:
+            uuid_bytes = base64.b64decode(field.text)
+            custom_icon_uuid = uuid.UUID(bytes=uuid_bytes)
+            return custom_icon_uuid
+        return
+
+    @uuid.setter
+    def uuid(self, uuid):
+        raise NotImplementedError()
+
+    @property
+    def data(self):
+        field = self._element.find('Data')
+        if field is not None:
+            data_bytes = base64.b64decode(field.text)
+            return data_bytes
+        return
+
+    @data.setter
+    def data(self, filename):
+        raise NotImplementedError()

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -2,7 +2,10 @@
 from __future__ import absolute_import, unicode_literals
 from future.utils import python_2_unicode_compatible
 
+import base64
+import uuid
 import logging
+
 from copy import deepcopy
 from datetime import datetime
 
@@ -176,6 +179,26 @@ class Entry(BaseElement):
         # Accept both str or list
         v = ';'.join(value if type(value) is list else [value])
         return self._set_subelement_text('Tags', v)
+
+    @property
+    def custom_icon_uuid(self):
+        if self._element.find('CustomIconUUID') is not None:
+            elem = self._element.find("CustomIconUUID")
+            icon_uuid = uuid.UUID(bytes = base64.b64decode(elem.text))
+            return icon_uuid
+        else:
+            return
+
+    @custom_icon_uuid.setter
+    def custom_icon_uuid(self, value):
+        if not isinstance(value, uuid.UUID):
+            raise TypeError("uuid.UUID is expected")
+        encoded_str = base64.b64encode(value.bytes)
+        elem = self._element.find("CustomIconUUID")
+        if elem is not None:
+            elem.text = encoded_str
+        else:
+            self._element.append(E.String(E.Key('CustomIconUUID'), E.Value(encoded_str)))
 
     @property
     def history(self):

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -16,6 +16,7 @@ from construct import Container, ChecksumError
 from lxml import etree
 from lxml.builder import E
 
+from pykeepass.custom_icon import CustomIcon
 from pykeepass.attachment import Attachment
 from pykeepass.entry import Entry
 from pykeepass.exceptions import *
@@ -649,6 +650,16 @@ class PyKeePass(object):
             raise UnableToSendToRecycleBin
         recyclebin_group = self._create_or_get_recyclebin_group()
         self.move_entry( entry, recyclebin_group)
+
+    # ---------- Custom Icons ----------
+
+    def find_custom_icon(self, uuid):
+        uuid_str = base64.b64encode(uuid.bytes).decode('utf-8')
+        xpath = '/KeePassFile/Meta/CustomIcons/Icon/UUID[text()="{}"]/..'.format(uuid_str)
+        custom_icon_element = self._xpath(xpath, first=True)
+        if custom_icon_element is not None:
+            return CustomIcon(element=custom_icon_element, kp=self)
+        return
 
     # ---------- Attachments ----------
 


### PR DESCRIPTION
KeePass has support for user supplied custom icons. Entries have a `CustomIconUUID` attribute. The value can be used to lookup the actual image data in the meta data. These two commits add support for querying custom icons for entries.

Possible follow up pull requests might add APIs for adding, updating and deleting custom icons.

The XML for a database that has custom icons set for entries looks something like this:

```
    <KeePassFile>
        <Meta>
            <Generator>KeePass</Generator>
            <DatabaseName>MyDatabase</DatabaseName>
            <CustomIcons>
                <Icon>
                    <UUID>7ZEzE75GLUy20VTG2l1e7A==</UUID>
                    <Data>iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADD ...</Data>
                </Icon>
                <Icon>
                    <UUID>IrcewadvNUGviELv9bgsYA==</UUID>
                    <Data>iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDP ...</Data>
                </Icon>
            </CustomIcons>
            <RecycleBinEnabled>True</RecycleBinEnabled>
            ...
```