### PR TITLE
Fix for setup.py, currently the dist package contains not just the pykeepass package but also the tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author="Philipp Schmitt",
     author_email="philipp@schmitt.co",
     url="https://github.com/libkeepass/pykeepass",
-    packages=find_packages(),
+    packages=find_packages(include=['pykeepass', 'pykeepass.*']),
     install_requires=[
         "python-dateutil",
         # FIXME python2 - last version to support python2


### PR DESCRIPTION
We are experiencing some conflicts due to the pykeepass pypi-dist-package not just containing the "pykeepass" python package but also the "tests" package.
With this small fix, the dist/wheel will not contain the tests package.