### PR TITLE
implements MasterKeyChangeForce Meta key

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -743,6 +743,32 @@ class PyKeePass(object):
         for reference in binaries_gt:
             reference.id = reference.id - 1
 
+    @property
+    def needs_password_change(self):
+        """Check whether a password change is necessary."""
+        return self.password_change_force_days >= 0
+
+    @property
+    def password_change_force_days(self):
+        """Check amount of days until password force reset."""
+        path = '/KeePassFile/Meta/MasterKeyChangeForce'
+        item = self._xpath(path, first=True)
+        value = item.text
+
+        assert value  # should be always present and non-empty
+        return int(value)
+
+    @password_change_force_days.setter
+    def password_change_force_days(self, value):
+        """Set amount of days until password force reset.
+
+        Args:
+            value (`int`): Number of days until reset (-1 to disable)
+        """
+        path = '/KeePassFile/Meta/MasterKeyChangeForce'
+        item = self._xpath(path, first=True)
+        item.text = repr(value)
+
 
 def create_database(
         filename, password=None, keyfile=None, transformed_key=None


### PR DESCRIPTION
This PR implements the forceful password change trigger which happens once a person opens the DB in a KDBX-compatible UI tool.

* The key name is defined [here](https://github.com/dlech/KeePass2.x/blob/6bb7f0cbe1afa5365fcdbed7adc124e82ac01fef/KeePassLib/Serialization/KdbxFile.cs#L118) and is always present in the DB XML.
* The type is always [C# Long](https://github.com/dlech/KeePass2.x/blob/6bb7f0cbe1afa5365fcdbed7adc124e82ac01fef/KeePassLib/Serialization/KdbxFile.Read.Streamed.cs#L248)
* The behavior is [triggered after >= 0 check](https://github.com/dlech/KeePass2.x/blob/0defb69f48687de62a4dbfad3213387371a3e8be/KeePass/Forms/DatabaseSettingsForm.cs#L235)

Closes #269 