### PR TITLE
Set autotype_sequence to None when adding entry

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -63,7 +63,7 @@ class Entry(BaseElement):
                 E.AutoType(
                     E.Enabled(str(autotype_enabled)),
                     E.DataTransferObfuscation('0'),
-                    E.DefaultSequence(str(autotype_sequence))
+                    E.DefaultSequence(str(autotype_sequence) if autotype_sequence else '')
                 )
             )
 
@@ -205,7 +205,7 @@ class Entry(BaseElement):
     @property
     def autotype_sequence(self):
         sequence = self._element.find('AutoType/DefaultSequence')
-        return sequence.text if sequence is not None else None
+        return sequence.text if sequence is not None and sequence.text is not '' else None
 
     @autotype_sequence.setter
     def autotype_sequence(self, value):

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -205,7 +205,9 @@ class Entry(BaseElement):
     @property
     def autotype_sequence(self):
         sequence = self._element.find('AutoType/DefaultSequence')
-        return sequence.text if sequence is not None and sequence.text is not '' else None
+        if sequence is None or sequence.text == '':
+            return None
+        return sequence.text
 
     @autotype_sequence.setter
     def autotype_sequence(self, value):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -230,6 +230,7 @@ class EntryFindTests3(KDBX3Tests):
         self.assertEqual(results.notes, unique_str + 'notes')
         self.assertEqual(results.tags, [unique_str + 'tags'])
         self.assertTrue(results.uuid != None)
+        self.assertTrue(results.autotype_sequence is None)
         # convert naive datetime to utc
         expiry_time_utc = expiry_time.replace(tzinfo=tz.gettz()).astimezone(tz.gettz('UTC'))
         self.assertEqual(results.icon, icons.KEY)
@@ -1087,3 +1088,4 @@ class KDBXTests(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
**Issue:** When adding a new entry, it sets the autotype_sequence to 'None' (as a string). 

**Proposed solution:** Checks on both autotype_sequence initializer and getter if the element is None or equal to ''.

Closes #284 