### PR TITLE
Allow extended properties on elements

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -81,11 +81,14 @@ class Entry(BaseElement):
         if field is not None:
             return field.text
 
-    def _set_string_field(self, key, value):
+    def _set_string_field(self, key, value, **kwargs):
         field = self._xpath('String/Key[text()="{}"]/..'.format(key), first=True)
         if field is not None:
             self._element.remove(field)
-        self._element.append(E.String(E.Key(key), E.Value(value)))
+        if kwargs:
+            self._element.append(E.String(E.Key(key), (E.Value(value, **kwargs))))
+        else:
+            self._element.append(E.String(E.Key(key), E.Value(value)))
 
     def _get_string_field_keys(self, exclude_reserved=False):
         results = [x.find('Key').text for x in self._element.findall('String')]
@@ -236,9 +239,9 @@ class Entry(BaseElement):
             p = p.parentgroup
         return path
 
-    def set_custom_property(self, key, value):
+    def set_custom_property(self, key, value, **kwargs):
         assert key not in reserved_keys, '{} is a reserved key'.format(key)
-        return self._set_string_field(key, value)
+        return self._set_string_field(key, value, *kwargs)
 
     def get_custom_property(self, key):
         assert key not in reserved_keys, '{} is a reserved key'.format(key)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -490,6 +490,7 @@ class EntryTests3(KDBX3Tests):
         entry.icon = icons.GLOBE
         entry.set_custom_property('foo', 'bar')
         entry.set_custom_property('multiline', 'hello\nworld')
+        entry.set_custom_property('seed', '0123456789', Protected=True)
 
         self.assertEqual(entry.title, changed_string + 'title')
         self.assertEqual(entry.username, changed_string + 'username')


### PR DESCRIPTION
 This relates to https://github.com/libkeepass/pykeepass/issues/194
 This patch allows to put an entry of a custom_property to protected memory, with
 argument Protected=True.
 Could be use for future properties, as it doesn't constrain on a fixed property
 name.