### PR TITLE
entry: Add is_custom_property_protected method

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -294,6 +294,25 @@ class Entry(BaseElement):
             raise AttributeError('Could not find property element')
         self._element.remove(prop)
 
+    def is_custom_property_protected(self, key):
+        """Whether a custom property is protected.
+
+        Return False if the entry does not have a custom property with the
+        specified key.
+
+        Args:
+            key (:obj:`str`): key of the custom property to check.
+
+        Returns:
+            bool: Whether the custom property is protected.
+
+        """
+        assert key not in reserved_keys, '{} is a reserved key'.format(key)
+        field = self._xpath('String/Key[text()="{}"]/../Value'.format(key), first=True)
+        if field is not None:
+            return field.attrib.get("Protected", "False") == "True"
+        return False
+
     @property
     def custom_properties(self):
         keys = self._get_string_field_keys(exclude_reserved=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -597,6 +597,16 @@ class EntryTests3(KDBX3Tests):
         self.assertEqual(len(entry.attachments), num_attach + 1)
         self.assertEqual(entry.attachments[0].filename, 'foobar2.txt')
 
+    def test_is_custom_property_protected(self):
+        e = self.kp.add_entry(self.kp.root_group, 'test-protect', 'some-user', 'pass')
+        e.set_custom_property('protected', 'something', protect=True)
+        e.set_custom_property('explicit-unprotected', 'other', protect=False)
+        e.set_custom_property('not-protected', 'secret')
+        self.assertTrue(e.is_custom_property_protected('protected'))
+        self.assertFalse(e.is_custom_property_protected('explicit-unprotected'))
+        self.assertFalse(e.is_custom_property_protected('not-protected'))
+        self.assertFalse(e.is_custom_property_protected('non-existent'))
+
 
 class EntryHistoryTests3(KDBX3Tests):
 


### PR DESCRIPTION
In Secrets we want to present protected custom properties with hidden text, so we need a way to query whether an attribute is protected.

My knowledge of lxml is just what you can see in the PR, so please tell me if there is a better way to achieve this.

See https://gitlab.gnome.org/World/secrets/-/merge_requests/721, specifically https://gitlab.gnome.org/World/secrets/-/merge_requests/721/diffs#234455d6642dc1a00aa62f6a0b9581fc403591c1_611_615 where we use this ~~hack~~ *method*. 