### PR TITLE
Support for "Enable Searching" property of groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 Pipfile.lock
 *.kdbx
 *.kdbx.out
+.venv/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "tests.py"
+    ],
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true
+}

--- a/pykeepass/group.py
+++ b/pykeepass/group.py
@@ -16,7 +16,7 @@ class Group(BaseElement):
 
     def __init__(self, name=None, element=None, icon=None, notes=None,
                  kp=None, expires=None, expiry_time=None, 
-                 enable_searching=None):
+                 searching_enabled=None):
 
         self._kp = kp
 
@@ -31,8 +31,8 @@ class Group(BaseElement):
             self._element.append(E.Name(name))
             if notes:
                 self._element.append(E.Notes(notes))
-            if isinstance(enable_searching, bool):
-                self._element.append(E.EnableSearching(str(enable_searching).lower()))
+            if isinstance(searching_enabled, bool):
+                self._element.append(E.EnableSearching(str(searching_enabled).lower()))
 
         else:
             assert type(element) in [_Element, Element, ObjectifiedElement], \
@@ -62,7 +62,7 @@ class Group(BaseElement):
         return self._set_subelement_text('Notes', value)
         
     @property
-    def enable_searching(self):
+    def searching_enabled(self):
         """bool: enable or disable search in this group"""
         if self._get_subelement_text('EnableSearching') == 'false':
             return False
@@ -72,14 +72,14 @@ class Group(BaseElement):
         else:
             return None
 
-    @enable_searching.setter
-    def enable_searching(self, value):
+    @searching_enabled.setter
+    def searching_enabled(self, value):
         if value is None:
             return self._set_subelement_text('EnableSearching', 'null')
         elif isinstance(value, bool):
             return self._set_subelement_text('EnableSearching', str(value).lower())
         else:
-            raise ValueError("enable_searching should be True, False or None")
+            raise ValueError("searching_enabled should be True, False or None")
 
     @property
     def entries(self):

--- a/pykeepass/group.py
+++ b/pykeepass/group.py
@@ -15,7 +15,8 @@ from pykeepass.baseelement import BaseElement
 class Group(BaseElement):
 
     def __init__(self, name=None, element=None, icon=None, notes=None,
-                 kp=None, expires=None, expiry_time=None):
+                 kp=None, expires=None, expiry_time=None, 
+                 enable_searching=None):
 
         self._kp = kp
 
@@ -30,6 +31,8 @@ class Group(BaseElement):
             self._element.append(E.Name(name))
             if notes:
                 self._element.append(E.Notes(notes))
+            if isinstance(enable_searching, bool):
+                self._element.append(E.EnableSearching(str(enable_searching).lower()))
 
         else:
             assert type(element) in [_Element, Element, ObjectifiedElement], \
@@ -57,6 +60,26 @@ class Group(BaseElement):
     @notes.setter
     def notes(self, value):
         return self._set_subelement_text('Notes', value)
+        
+    @property
+    def enable_searching(self):
+        """bool: enable or disable search in this group"""
+        if self._get_subelement_text('EnableSearching') == 'false':
+            return False
+        elif self._get_subelement_text('EnableSearching') == 'true':
+            return True
+        # Default option is 'null':
+        else:
+            return None
+
+    @enable_searching.setter
+    def enable_searching(self, value):
+        if value is None:
+            return self._set_subelement_text('EnableSearching', 'null')
+        elif isinstance(value, bool):
+            return self._set_subelement_text('EnableSearching', str(value).lower())
+        else:
+            raise ValueError("enable_searching should be True, False or None")
 
     @property
     def entries(self):

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -434,13 +434,16 @@ class PyKeePass(object):
         return res
 
     # creates a new group and all parent groups, if necessary
-    def add_group(self, destination_group, group_name, icon=None, notes=None):
+    def add_group(self, destination_group, group_name, icon=None, 
+			notes=None, enable_searching=None):
         logger.debug('Creating group {}'.format(group_name))
 
         if icon:
-            group = Group(name=group_name, icon=icon, notes=notes, kp=self)
+            group = Group(name=group_name, icon=icon, notes=notes, 
+				kp=self, enable_searching=enable_searching)
         else:
-            group = Group(name=group_name, notes=notes, kp=self)
+            group = Group(name=group_name, notes=notes, kp=self, 
+				enable_searching=enable_searching)
         destination_group.append(group)
 
         return group
@@ -456,6 +459,7 @@ class PyKeePass(object):
         if existing_group is not None:
             return existing_group
         kwargs.setdefault('group_name', 'Recycle Bin')
+        kwargs.setdefault('enable_searching', False)
         group = self.add_group( self.root_group, **kwargs)
         elem = self._xpath('/KeePassFile/Meta/RecycleBinUUID', first=True)
         elem.text = base64.b64encode(group.uuid.bytes).decode('utf-8')

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -435,15 +435,15 @@ class PyKeePass(object):
 
     # creates a new group and all parent groups, if necessary
     def add_group(self, destination_group, group_name, icon=None, 
-			notes=None, enable_searching=None):
+            notes=None, searching_enabled=None):
         logger.debug('Creating group {}'.format(group_name))
 
         if icon:
             group = Group(name=group_name, icon=icon, notes=notes, 
-				kp=self, enable_searching=enable_searching)
+                kp=self, searching_enabled=searching_enabled)
         else:
             group = Group(name=group_name, notes=notes, kp=self, 
-				enable_searching=enable_searching)
+                searching_enabled=searching_enabled)
         destination_group.append(group)
 
         return group
@@ -459,7 +459,7 @@ class PyKeePass(object):
         if existing_group is not None:
             return existing_group
         kwargs.setdefault('group_name', 'Recycle Bin')
-        kwargs.setdefault('enable_searching', False)
+        kwargs.setdefault('searching_enabled', False)
         group = self.add_group( self.root_group, **kwargs)
         elem = self._xpath('/KeePassFile/Meta/RecycleBinUUID', first=True)
         elem.text = base64.b64encode(group.uuid.bytes).decode('utf-8')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -382,7 +382,7 @@ class RecycleBinTests3(KDBX3Tests):
 
         self.assertIsNotNone(self.kp.recyclebin_group)
         self.assertEqual( len(self.kp.recyclebin_group.entries), 1)
-        self.assertIs(self.kp.recyclebin_group.enable_searching, False)
+        self.assertIs(self.kp.recyclebin_group.searching_enabled, False)
         
 
     def test_entry(self):
@@ -757,7 +757,7 @@ class GroupTests3(KDBX3Tests):
             expiry_time=time,
             icon=icons.KEY,
             kp=self.kp,
-            enable_searching=True
+            searching_enabled=True
         )
 
         self.assertEqual(group.name, 'name')
@@ -766,7 +766,7 @@ class GroupTests3(KDBX3Tests):
         self.assertEqual(group.expiry_time,
                          time.replace(tzinfo=tz.gettz()).astimezone(tz.gettz('UTC')))
         self.assertEqual(group.icon, icons.KEY)
-        self.assertEqual(group.enable_searching, True)
+        self.assertEqual(group.searching_enabled, True)
         
     def test_set_and_get_fields(self):
         time = datetime.now().replace(microsecond=0)
@@ -779,7 +779,7 @@ class GroupTests3(KDBX3Tests):
             expiry_time=time,
             icon=icons.KEY,
             kp=self.kp,
-            enable_searching=True   
+            searching_enabled=True   
         )
         
         group.name = changed_string + 'name'
@@ -787,13 +787,13 @@ class GroupTests3(KDBX3Tests):
         group.expires = False
         group.expiry_time = changed_time
         group.icon = icons.GLOBE
-        group.enable_searching = False
+        group.searching_enabled = False
         
 
         self.assertEqual(group.name, changed_string + 'name')
         self.assertEqual(group.notes, changed_string + 'notes')
         self.assertEqual(group.icon, icons.GLOBE)
-        self.assertEqual(group.enable_searching, False)
+        self.assertEqual(group.searching_enabled, False)
         # test time properties
         self.assertEqual(group.expires, False)
         self.assertEqual(group.expiry_time,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -382,6 +382,8 @@ class RecycleBinTests3(KDBX3Tests):
 
         self.assertIsNotNone(self.kp.recyclebin_group)
         self.assertEqual( len(self.kp.recyclebin_group.entries), 1)
+        self.assertIs(self.kp.recyclebin_group.enable_searching, False)
+        
 
     def test_entry(self):
         entry = self.kp.add_entry( self.kp.root_group, "RecycleBinTest2", "login", "password")
@@ -747,10 +749,56 @@ class EntryHistoryTests3(KDBX3Tests):
 class GroupTests3(KDBX3Tests):
 
     def test_fields(self):
-        self.assertEqual(
-            self.kp.find_groups(name='subgroup2', first=True).path,
-            ['foobar_group', 'subgroup', 'subgroup2']
+        time = datetime.now().replace(microsecond=0)
+        group = Group(
+            name='name',
+            notes='notes',
+            expires=True,
+            expiry_time=time,
+            icon=icons.KEY,
+            kp=self.kp,
+            enable_searching=True
         )
+
+        self.assertEqual(group.name, 'name')
+        self.assertEqual(group.notes, 'notes')
+        self.assertEqual(group.expires, True)
+        self.assertEqual(group.expiry_time,
+                         time.replace(tzinfo=tz.gettz()).astimezone(tz.gettz('UTC')))
+        self.assertEqual(group.icon, icons.KEY)
+        self.assertEqual(group.enable_searching, True)
+        
+    def test_set_and_get_fields(self):
+        time = datetime.now().replace(microsecond=0)
+        changed_time = time + timedelta(hours=9)
+        changed_string = 'changed_'
+        group = Group(
+            'name',
+            notes='notes',
+            expires=True,
+            expiry_time=time,
+            icon=icons.KEY,
+            kp=self.kp,
+            enable_searching=True   
+        )
+        
+        group.name = changed_string + 'name'
+        group.notes = changed_string + 'notes'
+        group.expires = False
+        group.expiry_time = changed_time
+        group.icon = icons.GLOBE
+        group.enable_searching = False
+        
+
+        self.assertEqual(group.name, changed_string + 'name')
+        self.assertEqual(group.notes, changed_string + 'notes')
+        self.assertEqual(group.icon, icons.GLOBE)
+        self.assertEqual(group.enable_searching, False)
+        # test time properties
+        self.assertEqual(group.expires, False)
+        self.assertEqual(group.expiry_time,
+                         changed_time.replace(tzinfo=tz.gettz()).astimezone(tz.gettz('UTC')))
+        
 
     def test_empty_group(self):
         # test that groups are properly emptied


### PR DESCRIPTION
Hello

Added support for reading and setting the `EnableSearching` parameter. Other keepass clients use this to set that search should find results in that group. 

On KepassXC and Keepass the trash group has this option enabled by default, I added the same behavior as well.

I didn't modify the `find_`... functions. Should I add support there as well, or only clients should implement this search filtering?

I added some tests for this new thing, and added some generic group attribute tests based on the similar entry tests. Should I add more, or is this enough?

Edit: TODO:

- [x] Rename to `searching_enabled`
- [ ] Add support in the `find_`... functions
- [ ] Add tests for the `find_`... functions
- [ ] Update readme

