### PR TITLE
add_entry(): Make otp= protected

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -57,7 +57,9 @@ class Entry(BaseElement):
             if notes:
                 self._element.append(E.String(E.Key('Notes'), E.Value(notes)))
             if otp:
-                self._element.append(E.String(E.Key('otp'), E.Value(otp)))
+                self._element.append(
+                    E.String(E.Key('otp'), E.Value(otp, Protected="True"))
+                )
             if tags:
                 self._element.append(
                     E.Tags(';'.join(tags) if type(tags) is list else tags)


### PR DESCRIPTION
When doing:
```python
kp.add_entry(kp.root_group, "title", "username", "password", otp="otpauth://")
```
The OTP will not be marked as protected, while this will be:
```python
entry = kp.add_entry(kp.root_group, "title", "username", "password")
entry.otp = "otpauth://"
```

This PR fixes `add_entry()` otp to be protected, in line with the property (and other clients).

(I did look into writing a unit test, but it looks like there's no way to know if the core properties are protected.  `is_custom_property_protected("otp")` will not work.)