### PR TITLE
Use __hash__ for BaseElement

### DIFF
--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -166,11 +166,13 @@ class BaseElement(object):
     def __repr__(self):
         return self.__str__()
 
+    def __hash__(self):
+        return hash((self.uuid,))
+
     def __eq__(self, other):
-        if hasattr(other, 'uuid'):
-            return self.uuid == other.uuid
-        else:
-            return False
+        if isinstance(other, BaseElement):
+            return hash(self) == hash(other)
+        return NotImplemented
 
     def touch(self, modify=False):
         """

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -385,6 +385,7 @@ class HistoryEntry(Entry):
         pathstr = super().__str__()
         return 'HistoryEntry: {}'.format(pathstr)
 
-    def __eq__(self, other):
-        # all history items share the same uuid, so examine xml directly
-        return self._element == other._element
+    def __hash__(self):
+        # All history items share the same UUID with themselves and their
+        # parent, so consider the mtime also
+        return hash((self.uuid, self.mtime))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -197,6 +197,8 @@ class EntryFindTests3(KDBX3Tests):
         hist = entry.history
         self.assertIsInstance(hist, list)
         self.assertEqual(len(hist), 4)
+        self.assertEqual(len(set(hist)), 4)
+        self.assertNotEqual(hist[0], hist[1])
 
     def test_history_path(self):
         for title in ["root_entry", "subentry"]:
@@ -469,6 +471,7 @@ class EntryTests3(KDBX3Tests):
 
     def test_references(self):
         original_entry = self.kp.find_entries(title='foobar_entry', first=True)
+        original_entry_duplicate = self.kp.find_entries(title='foobar_entry', first=True)
         clone1 = self.kp.find_entries(title='foobar_entry - Clone', first=True)
         clone2 = self.kp.find_entries(title='foobar_entry - Clone of clone', first=True)
         prefixed = self.kp.find_entries(title='foobar_entry - Clone with prefix and suffix', first=True)
@@ -478,6 +481,10 @@ class EntryTests3(KDBX3Tests):
         self.assertEqual(original_entry.ref('username'), clone1.username)
         self.assertEqual(prefixed.deref('username'), 'domain\\{}2'.format(original_entry.username))
         self.assertEqual(prefixed.deref('password'), 'A{}BC'.format(original_entry.password))
+        self.assertEqual(original_entry, original_entry_duplicate)
+        self.assertEqual(hash(original_entry), hash(original_entry_duplicate))
+        self.assertNotEqual(original_entry, clone1)
+        self.assertNotEqual(clone1, clone2)
 
     def test_set_and_get_fields(self):
         time = datetime.now().replace(microsecond=0)


### PR DESCRIPTION
- Allows for e.g. set() which uses hash() for deduplication
- Consider mtime for HistoryEntry equality
- Additional unit tests