### PR TITLE
entry: move entries within a group

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -119,6 +119,20 @@ class Entry(BaseElement):
             return results
 
     @property
+    def index(self):
+        group = self.group._element
+        children = group.getchildren()
+        first_index = self.group._first_entry
+        index = children.index(self._element)
+        return index - first_index
+
+    def move(self, new_index):
+        group = self.group._element
+        first_index = self.group._first_entry
+        group.remove(self._element)
+        group.insert(new_index+first_index, self._element)
+
+    @property
     def attachments(self):
         return self._kp.find_attachments(
             element=self,

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -120,6 +120,7 @@ class Entry(BaseElement):
 
     @property
     def index(self):
+        """int: get index of a entry within a group"""
         group = self.group._element
         children = group.getchildren()
         first_index = self.group._first_entry
@@ -127,6 +128,11 @@ class Entry(BaseElement):
         return index - first_index
 
     def reindex(self, new_index):
+        """Move entry to a new index within a group
+        
+        Args:
+            new_index (int): new index for the entry starting at 0
+        """
         group = self.group._element
         first_index = self.group._first_entry
         group.remove(self._element)

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -126,7 +126,7 @@ class Entry(BaseElement):
         index = children.index(self._element)
         return index - first_index
 
-    def move(self, new_index):
+    def reindex(self, new_index):
         group = self.group._element
         first_index = self.group._first_entry
         group.remove(self._element)

--- a/pykeepass/group.py
+++ b/pykeepass/group.py
@@ -41,6 +41,12 @@ class Group(BaseElement):
             self._element = element
 
     @property
+    def _first_entry(self):
+        children = self._element.getchildren()
+        first_element = next(e for e in children if e.tag == "Entry")
+        return children.index(first_element)
+
+    @property
     def name(self):
         """str: get or set group name"""
         return self._get_subelement_text('Name')

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -614,6 +614,17 @@ class EntryTests3(KDBX3Tests):
         self.assertFalse(e.is_custom_property_protected('not-protected'))
         self.assertFalse(e.is_custom_property_protected('non-existent'))
 
+    def test_reindex(self):
+        e1 = self.kp.add_entry(self.kp.root_group, 'Test-Index1', 'user-index', 'pass')
+        e2 = self.kp.add_entry(self.kp.root_group, 'Test-Index2', 'user-index', 'pass')
+        e3 = self.kp.add_entry(self.kp.root_group, 'Test-Index3', 'user-index', 'pass')
+        e4 = self.kp.add_entry(self.kp.root_group, 'Test-Index4', 'user-index', 'pass')
+        e2.reindex(0)
+        e3.reindex(0)
+        e4.reindex(0)
+        entries = self.kp.find_entries(username="user-index")
+        self.assertEqual(entries, [e4,e3,e2,e1])
+
 
 class EntryHistoryTests3(KDBX3Tests):
 


### PR DESCRIPTION
Code changes:
- Add `index` property to Entry
- Add `move` method to Entry
- Add `_first_entry` property to Group

Explanation:
To move Entries around we need to remove and then insert at the desired index, the KDBX format makes it so that Entries and group info is all mixed, so we have to get the first element index to position correctly the Entries.

If you know a better method to get the index of the first entry I'll put it in.

What it does:

It moves entries around a group, pretty self explanatory, like the Keepass and KeepassXC functionality.