### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,10 @@ license = {text = "GPL-3.0"}
 keywords = ["vault", "keepass"]
 dependencies = [
     "python-dateutil",
-    # FIXME python2 - last version to support python2
-    "construct==2.10.68",
+    "construct",
     "argon2_cffi",
     "pycryptodomex>=3.6.2",
     "lxml",
-    # FIXME python2
-    "future",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "pykeepass"
+readme = "README.rst"
+description = "Python library to interact with keepass databases (supports KDBX3 and KDBX4)"
+authors = [
+    { name = "Philipp Schmitt", email = "philipp@schmitt.co" }
+]
+license = {text = "GPL-3.0"}
+keywords = ["valorant", "vault", "keepass"]
+dependencies = [
+    "python-dateutil",
+    # FIXME python2 - last version to support python2
+    "construct==2.10.68",
+    "argon2_cffi",
+    "pycryptodomex>=3.6.2",
+    "lxml",
+    # FIXME python2
+    "future",
+]
+dynamic = ["version"]
+
+
+[project.urls]
+Homepage = "https://github.com/libkeepass/pykeepass"
+
+[tool.setuptools.dynamic]
+version = {attr = "pykeepass.version.__version__"}
+
+[tool.setuptools]
+packages = ["pykeepass"]
+include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Philipp Schmitt", email = "philipp@schmitt.co" }
 ]
 license = {text = "GPL-3.0"}
-keywords = ["valorant", "vault", "keepass"]
+keywords = ["vault", "keepass"]
 dependencies = [
     "python-dateutil",
     # FIXME python2 - last version to support python2


### PR DESCRIPTION
This project needs a `pyproject.toml` since in future versions of Python it will be required in order to install the package via pip.
It retains **100%** functionalty with the original `setup.py` having the dynamic version and all.