### PR TITLE
Depecrate Python2

### DIFF
--- a/pykeepass/attachment.py
+++ b/pykeepass/attachment.py
@@ -1,15 +1,7 @@
-# FIXME python2
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future.utils import python_2_unicode_compatible
-
 import pykeepass.entry
 
 from pykeepass.exceptions import BinaryError
 
-# FIXME python2
-@python_2_unicode_compatible
 class Attachment(object):
     def __init__(self, element=None, kp=None, id=None, filename=None):
         self._element = element

--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import base64
 import struct
 import uuid

--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -6,7 +6,7 @@ from lxml.builder import E
 from datetime import datetime
 
 
-class BaseElement(object):
+class BaseElement():
     """Entry and Group inherit from this class"""
 
     def __init__(self, element, kp=None, icon=None, expires=False,

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -1,7 +1,3 @@
-# FIXME python2
-from __future__ import absolute_import, unicode_literals
-from future.utils import python_2_unicode_compatible
-
 import logging
 from copy import deepcopy
 from datetime import datetime
@@ -28,8 +24,6 @@ reserved_keys = [
     'otp'
 ]
 
-# FIXME python2
-@python_2_unicode_compatible
 class Entry(BaseElement):
 
     def __init__(self, title=None, username=None, password=None, url=None,

--- a/pykeepass/group.py
+++ b/pykeepass/group.py
@@ -1,7 +1,3 @@
-# FIXME python2
-from __future__ import absolute_import, unicode_literals
-from future.utils import python_2_unicode_compatible
-
 from lxml.builder import E
 from lxml.etree import Element, _Element
 from lxml.objectify import ObjectifiedElement
@@ -10,8 +6,6 @@ import pykeepass.entry
 from pykeepass.baseelement import BaseElement
 
 
-# FIXME python2
-@python_2_unicode_compatible
 class Group(BaseElement):
 
     def __init__(self, name=None, element=None, icon=None, notes=None,

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -1,9 +1,4 @@
 # coding: utf-8
-
-# FIXME python2
-from __future__ import absolute_import, print_function, unicode_literals
-from future.utils import python_2_unicode_compatible
-
 import base64
 import logging
 import os
@@ -38,8 +33,6 @@ BLANK_DATABASE_LOCATION = os.path.join(os.path.dirname(os.path.realpath(__file__
 BLANK_DATABASE_PASSWORD = "password"
 
 
-# FIXME python2
-@python_2_unicode_compatible
 class PyKeePass(object):
     """Open a KeePass database
 

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -33,7 +33,7 @@ BLANK_DATABASE_LOCATION = os.path.join(os.path.dirname(os.path.realpath(__file__
 BLANK_DATABASE_PASSWORD = "password"
 
 
-class PyKeePass(object):
+class PyKeePass():
     """Open a KeePass database
 
     Args:

--- a/pykeepass/xpath.py
+++ b/pykeepass/xpath.py
@@ -1,6 +1,3 @@
-# FIXME python2
-from __future__ import unicode_literals
-
 attachment_xp = {
     False: {
         'id': '/Value[@Ref="{}"]/..',

--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -3,5 +3,4 @@ pycryptodomex==3.14.1
 construct==2.10.68
 argon2-cffi==21.3.0
 python-dateutil==2.8.2
-future==0.18.2
 Sphinx>=3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ pycryptodomex==3.14.1
 construct==2.10.68
 argon2-cffi==21.3.0
 python-dateutil==2.8.2
-future==0.18.2

--- a/setup.py
+++ b/setup.py
@@ -21,13 +21,10 @@ setup(
     packages=find_packages(include=['pykeepass', 'pykeepass.*']),
     install_requires=[
         "python-dateutil",
-        # FIXME python2 - last version to support python2
-        "construct==2.10.68",
+        "construct",
         "argon2_cffi",
         "pycryptodomex>=3.6.2",
         "lxml",
-        # FIXME python2
-        "future",
     ],
     include_package_data=True,
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-# FIXME python2
-from __future__ import unicode_literals
-
 import logging
 import os
 import shutil


### PR DESCRIPTION
I have removed all the future imports, and also I have removed the parent class of object since that was a workaround needed for Python2.

By the way:
`construct` just dropped the support, dropping tests and etc in https://github.com/construct/construct/commit/52c7cd23933d83922a289112a7c01dad7ffde5a3 (which is version 2.10.54) but it has been updated (several times) for some reason.
