### PR TITLE
Use relative imports

### DIFF
--- a/pykeepass/__init__.py
+++ b/pykeepass/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .pykeepass import PyKeePass, create_database
 
-from pykeepass.version import __version__
+from .version import __version__

--- a/pykeepass/attachment.py
+++ b/pykeepass/attachment.py
@@ -1,6 +1,5 @@
-import pykeepass.entry
-
-from pykeepass.exceptions import BinaryError
+from . import entry
+from .exceptions import BinaryError
 
 class Attachment(object):
     def __init__(self, element=None, kp=None, id=None, filename=None):
@@ -32,7 +31,7 @@ class Attachment(object):
     def entry(self):
         """Entry: get entry this attachment is associated with"""
         ancestor = self._element.getparent()
-        return pykeepass.entry.Entry(element=ancestor, kp=self._kp)
+        return entry.Entry(element=ancestor, kp=self._kp)
 
     @property
     def binary(self):

--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -1,5 +1,4 @@
 import base64
-import struct
 import uuid
 from lxml import etree
 from lxml.builder import E

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -5,8 +5,8 @@ from lxml.builder import E
 from lxml.etree import Element, _Element
 from lxml.objectify import ObjectifiedElement
 
-import pykeepass.attachment
-from pykeepass.baseelement import BaseElement
+from . import attachment
+from .baseelement import BaseElement
 
 logger = logging.getLogger(__name__)
 reserved_keys = [
@@ -126,7 +126,7 @@ class Entry(BaseElement):
         )
         self._element.append(element)
 
-        return pykeepass.attachment.Attachment(element=element, kp=self._kp)
+        return attachment.Attachment(element=element, kp=self._kp)
 
     def delete_attachment(self, attachment):
         attachment.delete()

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -1,13 +1,11 @@
 import logging
 from copy import deepcopy
-from datetime import datetime
 
 from lxml.builder import E
 from lxml.etree import Element, _Element
 from lxml.objectify import ObjectifiedElement
 
 import pykeepass.attachment
-import pykeepass.group
 from pykeepass.baseelement import BaseElement
 
 logger = logging.getLogger(__name__)

--- a/pykeepass/group.py
+++ b/pykeepass/group.py
@@ -2,8 +2,8 @@ from lxml.builder import E
 from lxml.etree import Element, _Element
 from lxml.objectify import ObjectifiedElement
 
-import pykeepass.entry
-from pykeepass.baseelement import BaseElement
+from .entry import Entry
+from .baseelement import BaseElement
 
 
 class Group(BaseElement):
@@ -55,7 +55,7 @@ class Group(BaseElement):
     @property
     def entries(self):
         """:obj:`list` of :obj:`Entry`: get list of entries in this group"""
-        return [pykeepass.entry.Entry(element=x, kp=self._kp) for x in self._element.findall('Entry')]
+        return [Entry(element=x, kp=self._kp) for x in self._element.findall('Entry')]
 
     @property
     def subgroups(self):

--- a/pykeepass/kdbx_parsing/__init__.py
+++ b/pykeepass/kdbx_parsing/__init__.py
@@ -1,1 +1,4 @@
 from .kdbx import KDBX
+from .kdbx4 import kdf_uuids
+
+__all__ = ["KDBX", "kdf_uuids"]

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -10,7 +10,6 @@ import zlib
 
 from binascii import Error as BinasciiError
 from construct import Container, ChecksumError, CheckError
-from copy import deepcopy
 from dateutil import parser, tz
 from datetime import datetime, timedelta
 from lxml import etree

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -16,13 +16,12 @@ from lxml import etree
 from lxml.builder import E
 from pathlib import Path
 
-from pykeepass.attachment import Attachment
-from pykeepass.entry import Entry
-from pykeepass.exceptions import *
-from pykeepass.group import Group
-from pykeepass.kdbx_parsing.kdbx import KDBX
-from pykeepass.kdbx_parsing.kdbx4 import kdf_uuids
-from pykeepass.xpath import attachment_xp, entry_xp, group_xp, path_xp
+from .attachment import Attachment
+from .entry import Entry
+from .exceptions import *
+from .group import Group
+from .kdbx_parsing import KDBX, kdf_uuids
+from .xpath import attachment_xp, entry_xp, group_xp, path_xp
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
There is not much to say here except a little detail, if you already reviewed the PR you might notice that inside `entry.py` and `attachment.py` I use this syntax `from . import entry` this is to import from the current package a specific module.
This is to avoid what is called circular imports, (and similar strategy was in place before this one).

Also I added a variable used in `pykeepass.py` to the `__init__.py` in `kdbx_parsing` since importing from the subpackage would be easier.