### PR TITLE
Remove shebang line from pykeepass/deprecated.py

### DIFF
--- a/pykeepass/deprecated.py
+++ b/pykeepass/deprecated.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-
-
 # ---------- Find functions ---------------
 # Use find_entries()/find_groups() instead
 


### PR DESCRIPTION
The file does not have the executable bit set in its filesystem permissions and is not script-like (no `if __name__ == "__main__"` and no interesting side effects), so a shebang is not useful.