### PR TITLE
Fix missing pykeepass.kdbx_parsing when built with modern tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Issues = "https://github.com/libkeepass/pykeepass/issues"
 Changelog = "https://github.com/libkeepass/pykeepass/blob/master/CHANGELOG.rst"
 
 [tool.setuptools]
-packages = ["pykeepass"]
+packages = ["pykeepass", "pykeepass.kdbx_parsing"]
 include-package-data = true
 
 [build-system]


### PR DESCRIPTION
Before:

```
$ python3 -m build
$  tar -tzf dist/pykeepass-4.0.7.tar.gz 
pykeepass-4.0.7/
pykeepass-4.0.7/LICENSE
pykeepass-4.0.7/MANIFEST.in
pykeepass-4.0.7/PKG-INFO
pykeepass-4.0.7/README.rst
pykeepass-4.0.7/pykeepass/
pykeepass-4.0.7/pykeepass/__init__.py
pykeepass-4.0.7/pykeepass/attachment.py
pykeepass-4.0.7/pykeepass/baseelement.py
pykeepass-4.0.7/pykeepass/blank_database.kdbx
pykeepass-4.0.7/pykeepass/deprecated.py
pykeepass-4.0.7/pykeepass/entry.py
pykeepass-4.0.7/pykeepass/exceptions.py
pykeepass-4.0.7/pykeepass/group.py
pykeepass-4.0.7/pykeepass/icons.py
pykeepass-4.0.7/pykeepass/pykeepass.py
pykeepass-4.0.7/pykeepass/version.py
pykeepass-4.0.7/pykeepass/xpath.py
pykeepass-4.0.7/pykeepass.egg-info/
pykeepass-4.0.7/pykeepass.egg-info/PKG-INFO
pykeepass-4.0.7/pykeepass.egg-info/SOURCES.txt
pykeepass-4.0.7/pykeepass.egg-info/dependency_links.txt
pykeepass-4.0.7/pykeepass.egg-info/requires.txt
pykeepass-4.0.7/pykeepass.egg-info/top_level.txt
pykeepass-4.0.7/pyproject.toml
pykeepass-4.0.7/setup.cfg
$ cd dist
$ python3 -m wheel unpack pykeepass-4.0.7-py3-none-any.whl 
Unpacking to: pykeepass-4.0.7...OK
$ find pykeepass-4.0.7/
pykeepass-4.0.7/
pykeepass-4.0.7/pykeepass
pykeepass-4.0.7/pykeepass/__init__.py
pykeepass-4.0.7/pykeepass/attachment.py
pykeepass-4.0.7/pykeepass/baseelement.py
pykeepass-4.0.7/pykeepass/blank_database.kdbx
pykeepass-4.0.7/pykeepass/deprecated.py
pykeepass-4.0.7/pykeepass/entry.py
pykeepass-4.0.7/pykeepass/exceptions.py
pykeepass-4.0.7/pykeepass/group.py
pykeepass-4.0.7/pykeepass/icons.py
pykeepass-4.0.7/pykeepass/pykeepass.py
pykeepass-4.0.7/pykeepass/version.py
pykeepass-4.0.7/pykeepass/xpath.py
pykeepass-4.0.7/pykeepass-4.0.7.dist-info
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/LICENSE
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/METADATA
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/WHEEL
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/top_level.txt
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/RECORD
```

After:

```

$ python3 -m build
$  tar -tzf dist/pykeepass-4.0.7.tar.gz 
pykeepass-4.0.7/
pykeepass-4.0.7/LICENSE
pykeepass-4.0.7/MANIFEST.in
pykeepass-4.0.7/PKG-INFO
pykeepass-4.0.7/README.rst
pykeepass-4.0.7/pykeepass/
pykeepass-4.0.7/pykeepass/__init__.py
pykeepass-4.0.7/pykeepass/attachment.py
pykeepass-4.0.7/pykeepass/baseelement.py
pykeepass-4.0.7/pykeepass/blank_database.kdbx
pykeepass-4.0.7/pykeepass/deprecated.py
pykeepass-4.0.7/pykeepass/entry.py
pykeepass-4.0.7/pykeepass/exceptions.py
pykeepass-4.0.7/pykeepass/group.py
pykeepass-4.0.7/pykeepass/icons.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/
pykeepass-4.0.7/pykeepass/kdbx_parsing/__init__.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/common.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/kdbx.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/kdbx3.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/kdbx4.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/pytwofish.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/twofish.py
pykeepass-4.0.7/pykeepass/pykeepass.py
pykeepass-4.0.7/pykeepass/version.py
pykeepass-4.0.7/pykeepass/xpath.py
pykeepass-4.0.7/pykeepass.egg-info/
pykeepass-4.0.7/pykeepass.egg-info/PKG-INFO
pykeepass-4.0.7/pykeepass.egg-info/SOURCES.txt
pykeepass-4.0.7/pykeepass.egg-info/dependency_links.txt
pykeepass-4.0.7/pykeepass.egg-info/requires.txt
pykeepass-4.0.7/pykeepass.egg-info/top_level.txt
pykeepass-4.0.7/pyproject.toml
pykeepass-4.0.7/setup.cfg
$ cd dist
$ python3 -m wheel unpack pykeepass-4.0.7-py3-none-any.whl 
Unpacking to: pykeepass-4.0.7...OK
$ find pykeepass-4.0.7/
pykeepass-4.0.7/
pykeepass-4.0.7/pykeepass
pykeepass-4.0.7/pykeepass/__init__.py
pykeepass-4.0.7/pykeepass/attachment.py
pykeepass-4.0.7/pykeepass/baseelement.py
pykeepass-4.0.7/pykeepass/blank_database.kdbx
pykeepass-4.0.7/pykeepass/deprecated.py
pykeepass-4.0.7/pykeepass/entry.py
pykeepass-4.0.7/pykeepass/exceptions.py
pykeepass-4.0.7/pykeepass/group.py
pykeepass-4.0.7/pykeepass/icons.py
pykeepass-4.0.7/pykeepass/pykeepass.py
pykeepass-4.0.7/pykeepass/version.py
pykeepass-4.0.7/pykeepass/xpath.py
pykeepass-4.0.7/pykeepass/kdbx_parsing
pykeepass-4.0.7/pykeepass/kdbx_parsing/__init__.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/common.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/kdbx.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/kdbx3.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/kdbx4.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/pytwofish.py
pykeepass-4.0.7/pykeepass/kdbx_parsing/twofish.py
pykeepass-4.0.7/pykeepass-4.0.7.dist-info
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/LICENSE
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/METADATA
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/WHEEL
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/top_level.txt
pykeepass-4.0.7/pykeepass-4.0.7.dist-info/RECORD
```

If you would rather not explicitly list all (sub)packages like this, see https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-simple-packages (but make sure you don’t accidentally install `tests/` directly into `site-packages`, a common pitfall).