### PR TITLE
also install pykeepass.kdbx_parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ Issues = "https://github.com/libkeepass/pykeepass/issues"
 Changelog = "https://github.com/libkeepass/pykeepass/blob/master/CHANGELOG.rst"
 
 [tool.setuptools]
-packages = ["pykeepass"]
+packages = ["pykeepass", "pykeepass.kdbx_parsing"]
 include-package-data = true
 
 [build-system]


### PR DESCRIPTION
Otherwise `import pykeepass` fails with
```
  File "pykeepass/__init__.py", line 2, in <module>
    from .pykeepass import PyKeePass, create_database
  File "pykeepass/pykeepass.py", line 22, in <module>
    from .kdbx_parsing import KDBX, kdf_uuids
ModuleNotFoundError: No module named 'pykeepass.kdbx_parsing'
```