### PR TITLE
Return `None` if `deref` encouters a broken reference (fixes #384)

### DIFF
--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -687,7 +687,7 @@ class PyKeePass:
             ref (str): KeePass reference string to another field
 
         Returns:
-            str or uuid.UUID
+            str, uuid.UUID or None if no match found
 
         [fieldref]: https://keepass.info/help/base/fieldrefs.html
         """

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -710,6 +710,8 @@ class PyKeePass:
             if search_in == 'uuid':
                 search_value = uuid.UUID(search_value)
             ref_entry = self.find_entries(first=True, **{search_in: search_value})
+            if ref_entry is None:
+                return None
             value = value.replace(ref, getattr(ref_entry, wanted_field))
         return self.deref(value)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -528,6 +528,20 @@ class EntryTests3(KDBX3Tests):
         self.assertNotEqual(original_entry, clone1)
         self.assertNotEqual(clone1, clone2)
 
+    def test_broken_reference(self):
+        # TODO: move the entry into test databases
+        broken_entry_title = 'broken reference'
+        self.kp.add_entry(
+            self.kp.root_group,
+            title=broken_entry_title,
+            username='{REF:U@I:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA}',
+            password='{REF:P@I:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA}',
+        )
+        broken_entry = self.kp.find_entries(title=broken_entry_title, first=True)
+        self.assertEqual(broken_entry.deref('username'), None)
+        self.assertEqual(broken_entry.deref('password'), None)
+        self.kp.delete_entry(broken_entry)
+
     def test_set_and_get_fields(self):
         time = datetime.now(timezone.utc).replace(microsecond=0)
         changed_time = time + timedelta(hours=9)


### PR DESCRIPTION
Hi I tried to fix the issue #384 and wrote a small test but I didn't mess with the test databases so I used `add_entry` and `delete_entry` to set up my testcase.
If a reference is broken the code will now just return `None` and won't raise an exception. I think this is better and can be caught easily by the caller of `deref`.