### PR TITLE
Package metadata version retrieval fix.

### DIFF
--- a/pykeepass/version.py
+++ b/pykeepass/version.py
@@ -1,5 +1,10 @@
 __all__= ["__version__"]
 
-# FIXME: switch to using importlib.metadata when dropping Python<=3.7
-import pkg_resources
-__version__ = pkg_resources.get_distribution('pykeepass').version
+try:
+    # Retrieval of metadata version for Python 3.8 and above
+    from importlib.metadata import version
+    __version__ = version('pykeepass')
+except ImportError:
+    # Fallback for older Python versions (< 3.8)
+    from pkg_resources import get_distribution
+    __version__ = get_distribution('pykeepass').version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
 license = {text = "GPL-3.0"}
 keywords = ["vault", "keepass"]
 dependencies = [
+    "setuptools; python_version<'3.8'",
     "construct>=2.10.53",
     "argon2_cffi>=18.1.0",
     "pycryptodomex>=3.6.2",


### PR DESCRIPTION
The package relies on `setuptools` to retrieve the package metadata version. However, this dependency is not included in `pyproject.toml`, leading to runtime errors, as described in issue #390.

Following the recommendation in the [`version.py`](https://github.com/libkeepass/pykeepass/blob/a2da6854af4c45487f6788fd693d921c26ca8eb5/pykeepass/version.py) module, the package will omit `pkg_resources.get_distribution` and instead utilize the built-in `importlib.metadata.version` method to retrieve the package version for Python version 3.8 and above.

For older Python versions (< 3.8), `setuptools` will be installed as a dependency.
