### PR TITLE
customicons by uuid

### DIFF
--- a/pykeepass/baseelement.py
+++ b/pykeepass/baseelement.py
@@ -78,7 +78,12 @@ class BaseElement:
 
     @property
     def icon(self):
-        return self._get_subelement_text('IconID')
+        """`str`: get or set entry icon. See `icons`"""
+        value = self._get_subelement_text('IconID')
+        if not int(value):
+            uuid = self._get_subelement_text('CustomIconUUID')
+            value = uuid if uuid is not None else value
+        return value
 
     @icon.setter
     def icon(self, value):

--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -16,6 +16,7 @@ reserved_keys = [
     'URL',
     'Tags',
     'IconID',
+    'CustomIconUUID',
     'Times',
     'History',
     'Notes',
@@ -238,7 +239,11 @@ class Entry(BaseElement):
     @property
     def icon(self):
         """`str`: get or set entry icon. See `icons`"""
-        return self._get_subelement_text('IconID')
+        value = self._get_subelement_text('IconID')
+        if not int(value):
+            uuid = self._get_subelement_text('CustomIconUUID')
+            value = uuid if uuid is not None else value
+        return value
 
     @icon.setter
     def icon(self, value):

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -872,6 +872,18 @@ class PyKeePass:
         for reference in binaries_gt:
             reference.id = reference.id - 1
 
+    @property
+    def customIcons(self):
+        """`dictionary` of `uuid(str):png(bytes)`: all attached custom icons in database."""
+        icons = {}
+        counter = 0
+        for elem in self._xpath('/KeePassFile/Meta/CustomIcons/Icon'):
+            if elem.text is not None:
+                counter+=1
+            else:
+                icons[elem.find('UUID').text] = base64.b64decode(elem.find('Data').text)
+        return icons
+
     # ---------- Misc ----------
 
     def deref(self, value):


### PR DESCRIPTION
This pull request slightly changes the behavior of `icon` property getter in BaseElement and Entry. If the icon is a custom one then its uuid is returned instead of the index (nothing changes for the embedded icons).
The new property (getter) `customIcons` in class PyKeePass returns a dictionary of `uuid(str):png(bytes)` containing all the attached custom icons in the database.
For the moment these are read-only operations.