### PR TITLE
Allow password to be skipped or set to None in add_entry

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -41,9 +41,11 @@ class Entry(BaseElement):
             )
             self._element.append(E.String(E.Key('Title'), E.Value(title)))
             self._element.append(E.String(E.Key('UserName'), E.Value(username)))
-            self._element.append(
-                E.String(E.Key('Password'), E.Value(password, Protected="True"))
-            )
+            # Allowing password to be None
+            if password is not None:
+                self._element.append(
+                    E.String(E.Key('Password'), E.Value(password, Protected="True"))
+                )
             if url:
                 self._element.append(E.String(E.Key('URL'), E.Value(url)))
             if notes:

--- a/pykeepass/pykeepass.py
+++ b/pykeepass/pykeepass.py
@@ -648,7 +648,7 @@ class PyKeePass:
 
 
     def add_entry(self, destination_group, title, username,
-                  password, url=None, notes=None, expiry_time=None,
+                  password=None, url=None, notes=None, expiry_time=None,
                   tags=None, otp=None, icon=None, force_creation=False):
 
         """Create a new entry


### PR DESCRIPTION
Fix: Allow skipping password or `password=None` in `add_entry`

This PR fixes an issue where skipping or passing `None` as the `password` to `add_entry` would raise a `TypeError`, due to `lxml` not accepting `None` when building XML elements.

According to the documentation:
https://libkeepass.github.io/pykeepass/pykeepass.html#PyKeePass.add_entry

> password (str or None): the password of the new entry

The documentation already states that `None` is allowed, but the code did not support it.

### What this PR does

- Skips adding the `<Password>` field entirely if `password` is `None`
- Matches the KeePass GUI behavior when no password is provided