### PR TITLE
Drop pkg_resources module, since that is only python <3.8

### DIFF
--- a/pykeepass/version.py
+++ b/pykeepass/version.py
@@ -1,10 +1,4 @@
 __all__= ["__version__"]
 
-try:
-    # Retrieval of metadata version for Python 3.8 and above
-    from importlib.metadata import version
-    __version__ = version('pykeepass')
-except ImportError:
-    # Fallback for older Python versions (< 3.8)
-    from pkg_resources import get_distribution
-    __version__ = get_distribution('pykeepass').version
+from importlib.metadata import version
+__version__ = version('pykeepass')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["vault", "keepass"]
 requires-python = ">=3.7"
 dependencies = [
     "pyotp>=2.9.0",
-    "setuptools; python_version<'3.8'",
+    "importlib-metadata",
     "construct>=2.10.53",
     "argon2_cffi>=18.1.0",
     "pycryptodomex>=3.6.2",


### PR DESCRIPTION
Since pykeepass dropped support for python <3.8, we can remove the hack to rely on setuptools' pkg_resources for these versions.

Also, we need to record the dependency on importlib-metadata, since this is otherwise not installed and attempted to fall back on the obsolete pkg_resources codepath.

Fixes #427 