### PR TITLE
add_entry: Allow None for title, username, password

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -39,10 +39,10 @@ class Entry(BaseElement):
                 expiry_time=expiry_time,
                 icon=icon
             )
-            self._element.append(E.String(E.Key('Title'), E.Value(title)))
-            self._element.append(E.String(E.Key('UserName'), E.Value(username)))
+            self._element.append(E.String(E.Key('Title'), E.Value(title or "")))
+            self._element.append(E.String(E.Key('UserName'), E.Value(username or "")))
             self._element.append(
-                E.String(E.Key('Password'), E.Value(password, Protected="True"))
+                E.String(E.Key('Password'), E.Value(password or "", Protected="True"))
             )
             if url:
                 self._element.append(E.String(E.Key('URL'), E.Value(url)))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -511,6 +511,19 @@ class EntryTests3(KDBX3Tests):
             self.kp.root_group
         )
 
+    def test_null_values(self):
+        """Set title, username, password to `None` as the docs allow"""
+        entry = Entry(
+            None,
+            None,
+            None,
+            kp=self.kp
+        )
+        self.assertEqual(entry.title, '')
+        self.assertEqual(entry.username, '')
+        self.assertEqual(entry.password, '')
+
+
     def test_references(self):
         original_entry = self.kp.find_entries(title='foobar_entry', first=True)
         original_entry_duplicate = self.kp.find_entries(title='foobar_entry', first=True)


### PR DESCRIPTION
Our docs allow None, so make it so. None gets translated to an empty string
in the XML for the "title", "username" and "password". There is a corresponding test which tests this case.

Fixes: https://github.com/libkeepass/pykeepass/issues/416