### PR TITLE
fix(entry): handle None values for title, username, and password

### DIFF
--- a/pykeepass/entry.py
+++ b/pykeepass/entry.py
@@ -39,10 +39,10 @@ class Entry(BaseElement):
                 expiry_time=expiry_time,
                 icon=icon
             )
-            self._element.append(E.String(E.Key('Title'), E.Value(title)))
-            self._element.append(E.String(E.Key('UserName'), E.Value(username)))
+            self._element.append(E.String(E.Key('Title'), E.Value(title if title is not None else "")))
+            self._element.append(E.String(E.Key('UserName'), E.Value(username if username is not None else "")))
             self._element.append(
-                E.String(E.Key('Password'), E.Value(password, Protected="True"))
+                E.String(E.Key('Password'), E.Value(password if password is not None else "", Protected="True"))
             )
             if url:
                 self._element.append(E.String(E.Key('URL'), E.Value(url)))


### PR DESCRIPTION
## Description
Fixes #416 

The documentation for `add_entry` explicitly states that `title`, `username`, and `password` can be `None`. However, when initializing a new `Entry` object, `E.Value()` would throw a `TypeError: bad argument type: NoneType(None)` if any of these arguments were actually `None`.

## Solution
This patch substitutes `None` with an empty string `""` for these three fields when creating the XML tags, effectively preventing the TypeError while correctly creating the necessary nodes.

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)